### PR TITLE
feat(menu): support deferred lifecycle-safe loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,26 @@ You have the option to override the default error handlers by using a parameter 
 
 Note: The `error` parameter is optional and can be omitted.
 
+## Deferred menu loading
+
+`fetchMenu()` is a setup-time helper built on Nuxt's `useFetch()`. Call it directly
+from `<script setup>` so Nuxt can register its hydration lifecycle hooks.
+
+When a menu should load later from `onMounted()`, a watcher, or an event handler,
+create the request with `useMenu()` during setup and execute it when needed:
+
+```vue
+<script lang="ts" setup>
+const { useMenu } = useDrupalCe()
+const { data: accountMenu, execute: loadAccountMenu } = useMenu('account', {
+  immediate: false,
+  server: false,
+})
+
+onMounted(() => loadAccountMenu())
+</script>
+```
+
 ## Previous options not supported in 2.x version
 
 The following options were support in 1.x but got dropped:

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -308,14 +308,18 @@ export const useDrupalCe = () => {
   }
 
   /**
-   * Fetches menu data from Drupal (configured by menuEndpoint option), handles errors
+   * Creates a Nuxt async-data request for menu data from Drupal.
+   *
+   * Call this composable during component setup. For an imperative request later in
+   * the component lifecycle, pass `immediate: false` and call the returned `execute`
+   * function from the event or lifecycle hook.
+   *
    * @param name Menu name being fetched
    * @param useFetchOptions Optional Nuxt useFetch options
-   * @param overrideErrorHandler Optional error handler
    * @param skipDrupalCeApiProxy Force skip the Drupal CE API proxy. Defaults to false.
    *                             The proxy might still be skipped if serverApiProxy is set to false globally.
    */
-  const fetchMenu = async (name: string, useFetchOptions: UseFetchOptions<any> = {}, overrideErrorHandler?: (error?: any) => void, skipDrupalCeApiProxy: boolean = false) => {
+  const useMenu = (name: string, useFetchOptions: UseFetchOptions<any> = {}, skipDrupalCeApiProxy: boolean = false): AsyncData<any, any> => {
     const nuxtApp = useNuxtApp()
     useFetchOptions = processFetchOptions(useFetchOptions)
     useFetchOptions.key = useFetchOptions.key || `menu-${name}`
@@ -350,7 +354,24 @@ export const useDrupalCe = () => {
       useFetchOptions.baseURL = getDrupalBaseUrl() + getCeApiEndpoint(false)
     }
 
-    const { data: menu, error } = await useFetch(menuPath, useFetchOptions)
+    return useFetch(menuPath, useFetchOptions)
+  }
+
+  /**
+   * Fetches menu data from Drupal (configured by menuEndpoint option), handles errors.
+   *
+   * This convenience helper must be called during component setup because it uses
+   * Nuxt's useFetch lifecycle internally. Use useMenu() when a deferred request needs
+   * to be executed from onMounted, a watcher, or an event handler.
+   *
+   * @param name Menu name being fetched
+   * @param useFetchOptions Optional Nuxt useFetch options
+   * @param overrideErrorHandler Optional error handler
+   * @param skipDrupalCeApiProxy Force skip the Drupal CE API proxy. Defaults to false.
+   *                             The proxy might still be skipped if serverApiProxy is set to false globally.
+   */
+  const fetchMenu = async (name: string, useFetchOptions: UseFetchOptions<any> = {}, overrideErrorHandler?: (error?: any) => void, skipDrupalCeApiProxy: boolean = false) => {
+    const { data: menu, error } = await useMenu(name, useFetchOptions, skipDrupalCeApiProxy)
 
     if (error.value) {
       overrideErrorHandler ? overrideErrorHandler(error) : menuErrorHandler(error)
@@ -695,6 +716,7 @@ export const useDrupalCe = () => {
     useCeApi,
     loadLibrary,
     fetchPage,
+    useMenu,
     fetchMenu,
     getMessages,
     getPage,

--- a/test/nuxt/fetchPageAndMenu.test.ts
+++ b/test/nuxt/fetchPageAndMenu.test.ts
@@ -87,4 +87,20 @@ describe('fetchPage and fetchMenu use the right API endpoints', () => {
       })
     })
   })
+
+  describe('useMenu', () => {
+    it('supports a deferred request executed later in the component lifecycle', async () => {
+      const { useMenu } = useDrupalCe()
+      const { data, execute } = useMenu('main', {
+        immediate: false,
+        key: 'main-deferred',
+      })
+
+      expect(data.value).toBeUndefined()
+
+      await execute()
+
+      expect(data.value?.items?.[0]?.title).toBe('Via Proxy Menu')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- rebuild this branch on the latest upstream `2.x`
- add a new `useMenu()` composable that returns Nuxt AsyncData
- keep `fetchMenu()` backward compatible for setup-time use
- document deferred, client-only menu loading
- add regression coverage for deferred execution

## Underlying issue

`fetchMenu()` wraps Nuxt's `useFetch()`. When it is first called from `onMounted()` during hydration, Nuxt registers the immediate request for the component's `beforeMount` lifecycle. That lifecycle has already completed, so the request never executes and the menu data remains undefined until another navigation or render cycle occurs.

A direct client-side `$fetch` fallback avoided the symptom, but bypassed the normal AsyncData contract and did not address the lifecycle mismatch.

## Proposed solution

`useMenu()` creates the AsyncData request during setup and exposes `execute()`. Consumers that need lifecycle-controlled loading can initialize it with `immediate: false` and call `execute()` later:

```ts
const { useMenu } = useDrupalCe()

const { data: accountMenu, execute: loadAccountMenu } = useMenu('account', {
  immediate: false,
  server: false,
})

onMounted(() => loadAccountMenu())
```

Existing setup-time callers can continue using `fetchMenu()` unchanged.

## Validation

- Nuxt and packaging suites: 19 files, 103 tests passed
- focused menu suite: 7 tests passed
- changed-file ESLint passed
- package build/prepack passed

The full local E2E command could not complete because the test ports were already occupied and the expected Playwright browser binary was not installed; GitHub CI is running the complete project workflow.
