### PR TITLE
docs: demo and document loading Drupal JS libraries in the playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,45 +228,17 @@ x node-custom--default.vue
 
 ## Loading Drupal JavaScript libraries
 
-Drupal attaches JavaScript libraries to the render arrays it converts to custom
-elements - form `#states`, autocomplete, module behaviors. The backend emits
-one `drupal-library-*` element per attached library alongside the markup, in
-dependency order, each carrying the library's resolved JS files; the first one
-also carries the merged `drupalSettings` as a JSON string:
+The backend emits the JavaScript libraries attached to a rendered form, block or
+component as `drupal-library-*` elements. To load them, add a global
+`drupal-library--default.vue` component - see
+`playground/components/global/drupal-library--default.vue` for a renderless
+reference component handing the library to `useDrupalCe().loadLibrary()`, and
+`/form/states` in the playground for a form whose conditional field is driven
+this way.
 
-```json
-{
-  "element": "drupal-library-core-drupal-states",
-  "props": {
-    "library": "core/drupal.states",
-    "js": [{ "url": "/core/misc/states.js?v=11.3.13", "attributes": [] }],
-    "drupalSettings": "{\"ajaxTrustedUrl\":{\"form_action_p_4kMHZg\":true}}"
-  }
-}
-```
-
-To load them, add a global `drupal-library--default.vue` component - the
-default-component lookup resolves it for every `drupal-library-*` element. It is
-renderless and hands the library to `useDrupalCe().loadLibrary()`; see
-`playground/components/global/drupal-library--default.vue` for the reference
-component, and `/form/states` in the playground for a form whose conditional
-field is driven this way.
-
-`loadLibrary()` lazy-loads the actual loader, so pages that render no library
-never fetch it. The loader resolves the file URLs against `drupalBaseUrl`,
-appends them as `<script>` tags in the requested order, loads each URL once
-across all libraries, merges `drupalSettings` into `window.drupalSettings`
-before any script runs, and calls `Drupal.attachBehaviors()` once the batch has
-loaded. A file that fails to load is skipped with a warning rather than
-aborting the batch. Stylesheets are not loaded: the frontend brings its own.
-
-### Overriding a library
-
-To replace a library with a native implementation, or to skip it, add a
-component named after its element tag - `drupal-library-core-drupal-states.vue`
-for `core/drupal.states`. It takes precedence over the default component, so the
-library's JS is never loaded; a component rendering nothing skips the library
-entirely.
+Docs: [Drupal JS libraries](https://lupus-decoupled.org/nuxt/drupal-libraries)
+for the Nuxt side, [Drupal JavaScript](https://lupus-decoupled.org/advanced-topics/drupal-javascript)
+for what the backend sends.
 
 ## Component Preview Integration
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,48 @@ x node-custom--default.vue
 ✓ node--default.vue
 ```
 
+## Loading Drupal JavaScript libraries
+
+Drupal attaches JavaScript libraries to the render arrays it converts to custom
+elements - form `#states`, autocomplete, module behaviors. The backend emits
+one `drupal-library-*` element per attached library alongside the markup, in
+dependency order, each carrying the library's resolved JS files; the first one
+also carries the merged `drupalSettings` as a JSON string:
+
+```json
+{
+  "element": "drupal-library-core-drupal-states",
+  "props": {
+    "library": "core/drupal.states",
+    "js": [{ "url": "/core/misc/states.js?v=11.3.13", "attributes": [] }],
+    "drupalSettings": "{\"ajaxTrustedUrl\":{\"form_action_p_4kMHZg\":true}}"
+  }
+}
+```
+
+To load them, add a global `drupal-library--default.vue` component - the
+default-component lookup resolves it for every `drupal-library-*` element. It is
+renderless and hands the library to `useDrupalCe().loadLibrary()`; see
+`playground/components/global/drupal-library--default.vue` for the reference
+component, and `/form/states` in the playground for a form whose conditional
+field is driven this way.
+
+`loadLibrary()` lazy-loads the actual loader, so pages that render no library
+never fetch it. The loader resolves the file URLs against `drupalBaseUrl`,
+appends them as `<script>` tags in the requested order, loads each URL once
+across all libraries, merges `drupalSettings` into `window.drupalSettings`
+before any script runs, and calls `Drupal.attachBehaviors()` once the batch has
+loaded. A file that fails to load is skipped with a warning rather than
+aborting the batch. Stylesheets are not loaded: the frontend brings its own.
+
+### Overriding a library
+
+To replace a library with a native implementation, or to skip it, add a
+component named after its element tag - `drupal-library-core-drupal-states.vue`
+for `core/drupal.states`. It takes precedence over the default component, so the
+library's JS is never loaded; a component rendering nothing skips the library
+entirely.
+
 ## Component Preview Integration
 
 Built-in support for [nuxt-component-preview](https://github.com/drunomics/nuxt-component-preview) enables fully-rendered component previews in Drupal and easy Drupal Canvas integration. It works automatically with your `drupalBaseUrl` - CORS is configured automatically.

--- a/playground/public/core/misc/drupal.js
+++ b/playground/public/core/misc/drupal.js
@@ -1,0 +1,20 @@
+/**
+ * Minimal stand-in for Drupal core's drupal.js, for the playground demo.
+ *
+ * Provides just enough of the global Drupal object for a library to register a
+ * behavior and for the loader to run Drupal.attachBehaviors() once the library
+ * has loaded. Loaded first because states.js builds on it — the order the
+ * backend resolved and the loader preserves.
+ */
+window.Drupal = window.Drupal || { behaviors: {} }
+
+window.Drupal.attachBehaviors = function (context, settings) {
+  context = context || document
+  settings = settings || window.drupalSettings
+  Object.keys(window.Drupal.behaviors).forEach(function (id) {
+    const behavior = window.Drupal.behaviors[id]
+    if (typeof behavior.attach === 'function') {
+      behavior.attach(context, settings)
+    }
+  })
+}

--- a/playground/public/core/misc/states.js
+++ b/playground/public/core/misc/states.js
@@ -1,0 +1,26 @@
+/**
+ * Minimal stand-in for Drupal core's states.js, for the playground demo.
+ *
+ * Implements only the "visible when a checkbox is checked" condition, which is
+ * enough to show a Drupal library driving server-rendered markup in the
+ * decoupled frontend. Core resolves the full #states grammar and its jQuery
+ * selectors; here the `:input` prefix is dropped to get a plain CSS selector.
+ */
+window.Drupal.behaviors.states = {
+  attach(context) {
+    context.querySelectorAll('[data-drupal-states]').forEach((element) => {
+      const condition = JSON.parse(element.dataset.drupalStates).visible
+      const selector = Object.keys(condition)[0]
+      const input = document.querySelector(selector.replace(':input', ''))
+      if (!input || input.dataset.statesBound) {
+        return
+      }
+      input.dataset.statesBound = 'true'
+      const update = () => {
+        element.hidden = input.checked !== condition[selector].checked
+      }
+      input.addEventListener('change', update)
+      update()
+    })
+  },
+}

--- a/playground/server/routes/ce-api/api/menu_items/main.ts
+++ b/playground/server/routes/ce-api/api/menu_items/main.ts
@@ -48,6 +48,22 @@ export default defineEventHandler(() => [
     options: []
   },
   {
+    key: 'states-form-demo',
+    title: 'Conditional form',
+    description: null,
+    uri: 'form\/states',
+    alias: 'form\/states',
+    external: false,
+    absolute: 'https:\/\/8080-drunomics-lupusdecouple-fd0ilwlpax7.ws-eu84.gitpod.io\/form\/states',
+    relative: '\/form\/states',
+    existing: true,
+    weight: '0',
+    expanded: false,
+    enabled: true,
+    uuid: 'states-form-demo',
+    options: []
+  },
+  {
     key: 'layout-builder-demo',
     title: 'Layout',
     description: null,

--- a/playground/server/routes/ce-api/form/states.get.ts
+++ b/playground/server/routes/ce-api/form/states.get.ts
@@ -1,0 +1,48 @@
+/**
+ * A form whose conditional field is driven by a Drupal JavaScript library.
+ *
+ * Mirrors what Drupal emits for a render array with #attached libraries: one
+ * <drupal-library-*> element per library, in dependency order, as siblings of
+ * the markup, each carrying its resolved JS files. The first one also carries
+ * the merged drupalSettings, as a JSON string.
+ *
+ * The JS files are served by this playground backend from public/core/misc/ as
+ * minimal stand-ins for Drupal core's drupal.js and states.js.
+ */
+export default defineEventHandler(() => ({
+  title: 'Conditional form',
+  messages: [],
+  breadcrumbs: [{ frontpage: true, url: '/', label: 'Home' }],
+  metatags: { meta: [], link: [] },
+  content_format: 'json',
+  content: {
+    element: 'drupal-form',
+    props: {
+      formId: 'states_demo_form',
+      attributes: { class: ['states-demo-form'], dataDrupalSelector: 'states-demo-form' },
+      method: 'post',
+    },
+    slots: {
+      default: [
+        {
+          element: 'drupal-library-core-drupal',
+          props: {
+            library: 'core/drupal',
+            js: [{ url: '/core/misc/drupal.js?v=1', attributes: [] }],
+            drupalSettings: '{"states_demo":{"greeting":"Hello from drupalSettings"}}',
+          },
+        },
+        {
+          element: 'drupal-library-core-drupal-states',
+          props: {
+            library: 'core/drupal.states',
+            js: [{ url: '/core/misc/states.js?v=1', attributes: [] }],
+          },
+        },
+        '<div class="js-form-item form-item">\n <input data-drupal-selector="edit-show-message" type="checkbox" id="edit-show-message" name="show_message" value="1" class="form-checkbox" />\n <label for="edit-show-message" class="form-item__label">Show message field</label>\n</div>\n<div class="js-form-item form-item" data-drupal-selector="edit-message" data-drupal-states="{&quot;visible&quot;:{&quot;:input[name=\\u0022show_message\\u0022]&quot;:{&quot;checked&quot;:true}}}">\n <label for="edit-message" class="form-item__label">Message</label>\n <input type="text" id="edit-message" name="message" value="" size="60" maxlength="255" class="form-text" />\n</div>\n<input class="button--primary button js-form-submit form-submit" data-drupal-selector="edit-submit" type="submit" id="edit-submit" name="op" value="Submit" />\n',
+      ],
+    },
+  },
+  page_layout: 'default',
+  local_tasks: [],
+}))

--- a/test/e2e/drupalLibrary.test.ts
+++ b/test/e2e/drupalLibrary.test.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { setup, createPage } from '@nuxt/test-utils/e2e'
+import DrupalCe from '../../'
+
+describe('Drupal library loading', async () => {
+  await setup({
+    rootDir: join(fileURLToPath(import.meta.url), '../../../playground'),
+    nuxtConfig: {
+      modules: [
+        DrupalCe,
+      ],
+      drupalCe: {
+        drupalBaseUrl: 'http://127.0.0.1:3013',
+        ceApiEndpoint: '/ce-api',
+      },
+    },
+    port: 3013,
+  })
+
+  it('loads the libraries of a form in dependency order and attaches behaviors', async () => {
+    const page = await createPage('/form/states')
+
+    // The <drupal-library-*> elements render nothing themselves.
+    expect(await page.locator('drupal-library-core-drupal').count()).toBe(0)
+
+    await page.waitForFunction(() => Boolean((window as any).Drupal?.behaviors?.states))
+
+    // Scripts are injected in the order the backend resolved them.
+    const scripts = await page.evaluate(() =>
+      [...document.querySelectorAll('script[data-drupal-library]')].map(el => new URL((el as HTMLScriptElement).src).pathname))
+    expect(scripts).toEqual(['/core/misc/drupal.js', '/core/misc/states.js'])
+
+    // drupalSettings of the first library element is merged into the global.
+    expect(await page.evaluate(() => (window as any).drupalSettings?.states_demo?.greeting)).toBe('Hello from drupalSettings')
+
+    // The behavior attached to the server-rendered markup: the conditional
+    // field is hidden until the checkbox is ticked.
+    const message = page.locator('[data-drupal-selector="edit-message"]')
+    await expect.poll(() => message.isHidden()).toBe(true)
+
+    await page.locator('input[name="show_message"]').check()
+    expect(await message.isVisible()).toBe(true)
+  }, 20000)
+})


### PR DESCRIPTION
The backend emits `<drupal-library-*>` elements for the libraries attached to a render array, and the module loads them via `useDrupalCe().loadLibrary()` (shipped in 2.7.0) — but nothing in the playground exercised that path, and the README did not mention the feature at all.

## Changes

- **Playground demo** — `/form/states`: a mock CE-API response mirroring what Drupal emits, i.e. one `drupal-library-*` element per attached library in dependency order (`core/drupal`, then `core/drupal.states`), `drupalSettings` as a JSON string on the first one, and the form markup carrying `data-drupal-states`. Linked from the playground main menu.
- **Stand-in library JS** — `playground/public/core/misc/drupal.js` + `states.js`: minimal versions of the core files the mock backend claims to serve, so the demo actually toggles the conditional field. They provide `Drupal.behaviors` / `Drupal.attachBehaviors` and a "visible when checked" `#states` condition, nothing more.
- **E2E coverage** — `test/e2e/drupalLibrary.test.ts`: asserts the library elements render nothing, the scripts are injected in the backend-resolved order, `drupalSettings` lands in the global, and the behavior attaches to the server-rendered markup (conditional field hidden until the checkbox is ticked).
- **README** — a brief "Loading Drupal JavaScript libraries" section: what to add, where the reference component lives, and links to the docs site for the details — [Drupal JS libraries](https://lupus-decoupled.org/nuxt/drupal-libraries) for the Nuxt side, [Drupal JavaScript](https://lupus-decoupled.org/advanced-topics/drupal-javascript) for what the backend sends. Those two pages are added in drunomics/lupus-decoupled-website#215.

## Verified

- `npx vitest run` — 33 files / 142 tests pass, including the new e2e case.
- `npm run lint` — no new findings (the one pre-existing error in `drupal-view--default.vue` is untouched).

---
Drafted with Claude Code from the loki dev VM.