### PR TITLE
fix: menu not refetched on locale switch (fetchMenu cache key is not locale-aware)

### DIFF
--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -318,7 +318,6 @@ export const useDrupalCe = () => {
   const fetchMenu = async (name: string, useFetchOptions: UseFetchOptions<any> = {}, overrideErrorHandler?: (error?: any) => void, skipDrupalCeApiProxy: boolean = false) => {
     const nuxtApp = useNuxtApp()
     useFetchOptions = processFetchOptions(useFetchOptions)
-    useFetchOptions.key = useFetchOptions.key || `menu-${name}`
     useFetchOptions.getCachedData = (key) => {
       if (nuxtApp.payload.data[key]) {
         return nuxtApp.payload.data[key]
@@ -341,6 +340,13 @@ export const useDrupalCe = () => {
     else {
       menuPath.value = sanitizeMenuPath(menuPath.value)
     }
+
+    // The key must vary with the localized menu path: with a fixed key,
+    // getCachedData keeps serving the previous language's menu from the
+    // payload cache after a locale switch. Deriving the key from menuPath
+    // also keeps key and request URL in sync (a single reactive source),
+    // so the refetch cannot race between old URL and new key.
+    useFetchOptions.key = useFetchOptions.key || computed(() => `menu-${name}--${menuPath.value}`)
 
     // Override baseURL specifically for menu endpoints
     if (config.serverApiProxy && !skipDrupalCeApiProxy) {

--- a/test/nuxt/fetchPageAndMenu.test.ts
+++ b/test/nuxt/fetchPageAndMenu.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment nuxt
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { registerEndpoint } from '@nuxt/test-utils/runtime'
 import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
 import { useNuxtApp } from '#imports'
@@ -84,6 +84,22 @@ describe('fetchPage and fetchMenu use the right API endpoints', () => {
         const { fetchMenu } = useDrupalCe()
         const result = await fetchMenu('main', { key: 'main-localized-direct' }, undefined, true)
         expect(result.value?.items?.[0]?.title).toBe('Direct API Menu FR')
+      })
+
+      it('refetches the menu when the locale changes', async () => {
+        const nuxtApp = useNuxtApp()
+        const locale = ref('en')
+        nuxtApp.$i18n = { locale, defaultLocale: 'en' }
+        nuxtApp.$localePath = (path: string) => locale.value === 'en' ? path : `/${locale.value}${path}`
+
+        const { fetchMenu } = useDrupalCe()
+        const result = await fetchMenu('main')
+        expect(result.value?.items?.[0]?.title).toBe('Via Proxy Menu')
+
+        locale.value = 'fr'
+        await vi.waitFor(() => {
+          expect(result.value?.items?.[0]?.title).toBe('Via Proxy Menu FR')
+        })
       })
     })
   })


### PR DESCRIPTION
## Bug

With `useLocalizedMenuEndpoint: true` (the default) and i18n enabled, `fetchMenu()` rebuilds the localized menu path when the locale changes, but caches the result under a fixed key:

```js
useFetchOptions.key = useFetchOptions.key || `menu-${name}`
useFetchOptions.getCachedData = (key) => {
  if (nuxtApp.payload.data[key]) {
    return nuxtApp.payload.data[key]
  }
}
```

When the locale changes, the `watch` on `$i18n.locale` updates `menuPath` and triggers a refetch — but since Nuxt 4's `experimental.granularCachedData` (default `true`), `getCachedData` is consulted on watch-triggered refetches too. It always finds the previous language's menu under the fixed `menu-${name}` key and returns it, so no request is made and rendered menus stay in the first-loaded language indefinitely.

**Reproduce:** Nuxt 4 app with this module + `@nuxtjs/i18n` (`strategy: 'prefix_except_default'`), a component rendering `await fetchMenu('main')`, translated menu items in Drupal. Load a page, switch language client-side (e.g. via `switchLocalePath`): page content and URL change, the menu does not, and no menu request is made.

## Fix

Derive the key from the same reactive `menuPath` the request uses, after the localization block:

```js
useFetchOptions.key = useFetchOptions.key || computed(() => `menu-${name}--${menuPath.value}`)
```

Each locale gets its own cache entry, and because key and URL derive from the same ref they change atomically. (Just passing a per-locale key from the app is not a reliable workaround: the caller's key and the module-internal `menuPath` update in separate watcher jobs, which races — the old-language response can land under the new key. Observed both outcomes across runs.)

Explicit keys passed via `useFetchOptions.key` keep working unchanged.

## Tests

Added a regression test (`refetches the menu when the locale changes`) — it fails against the previous implementation and passes with this change. Full `test/nuxt` suite passes (100 tests), eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)