### PR TITLE
feat: Add support for drupal form handling via Drupal ajax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ is added automatically to requests. Defaults to `false`.
 
 - `enableComponentPreview`: Enable component preview for Drupal Canvas integration. Automatically configures CORS based on `drupalBaseUrl`. Set to `false` to disable. Defaults to `true`.
 
+- `skipLibraryScripts`: List of URL substrings for Drupal JS files the library loader must not load (in addition to `core/misc/drupalSettingsLoader.js`, which is always skipped). Defaults to `[]`.
+
 ## Overriding options with environment variables
 
 Runtime config values can be overridden with environment variables via `NUXT_PUBLIC_` prefix. Supported runtime overrides:

--- a/playground/.nuxtrc
+++ b/playground/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@nuxt/test-utils="4.1.0"

--- a/playground/components/global/drupal-library--default.vue
+++ b/playground/components/global/drupal-library--default.vue
@@ -47,7 +47,7 @@ export default defineComponent({
     const { loadLibrary } = useDrupalCe()
 
     onMounted(() => {
-      loadLibrary({ js: props.js, drupalSettings: props.drupalSettings })
+      loadLibrary({ name: props.library, js: props.js, drupalSettings: props.drupalSettings })
     })
 
     // Renderless: emit no markup.

--- a/playground/components/global/drupal-library--default.vue
+++ b/playground/components/global/drupal-library--default.vue
@@ -55,3 +55,17 @@ export default defineComponent({
   },
 })
 </script>
+
+<style>
+/*
+ * Core ships `.js .js-hide { display: none }` in its `system/base` CSS, which
+ * the decoupled frontend deliberately never loads. Without it, elements Drupal
+ * marks as JS-only stay visible — e.g. a managed_file element's "Upload" button,
+ * which is `js-hide` because its auto-upload behaviour replaces it. `core/drupal`
+ * (misc/drupal.init.js) already adds the `js` class to <html>, so this rule
+ * applies as soon as a Drupal library is on the page.
+ */
+.js .js-hide {
+  display: none;
+}
+</style>

--- a/playground/server/routes/ce-api/form/upload.post.ts
+++ b/playground/server/routes/ce-api/form/upload.post.ts
@@ -14,6 +14,10 @@ export default defineEventHandler((event) => {
   if (query.ajax_form) {
     setResponseHeader(event, 'X-Drupal-Ajax-Token', '1')
     setResponseHeader(event, 'Content-Type', 'application/json')
+    // An allow-listed header (in the default passThroughHeaders) and one that is
+    // not, to prove the proxy obeys the configured allow-list on AJAX responses.
+    setResponseHeader(event, 'X-Drupal-Cache', 'MISS')
+    setResponseHeader(event, 'X-Custom-Debug', 'should-be-dropped')
     return [
       {
         command: 'insert',

--- a/playground/server/routes/ce-api/form/upload.post.ts
+++ b/playground/server/routes/ce-api/form/upload.post.ts
@@ -1,0 +1,40 @@
+import { defineEventHandler, getQuery, setResponseHeader } from 'h3'
+
+/**
+ * Mock backend for a managed_file webform endpoint.
+ *
+ * On an AJAX form request (?ajax_form=1, as posted by a managed_file
+ * upload/remove button) it mimics Drupal: a JSON array of AJAX commands plus the
+ * X-Drupal-Ajax-Token verification header that ajax.js checks. Otherwise it
+ * behaves like a normal full submit and returns a custom-elements page.
+ */
+export default defineEventHandler((event) => {
+  const query = getQuery(event)
+
+  if (query.ajax_form) {
+    setResponseHeader(event, 'X-Drupal-Ajax-Token', '1')
+    setResponseHeader(event, 'Content-Type', 'application/json')
+    return [
+      {
+        command: 'insert',
+        method: 'replaceWith',
+        selector: '#edit-speisekarte-wrapper',
+        data: '<div id="edit-speisekarte-wrapper">file uploaded</div>',
+      },
+    ]
+  }
+
+  return {
+    title: 'Form response',
+    messages: [],
+    breadcrumbs: [{ frontpage: true, url: '/', label: 'Home' }],
+    metatags: { meta: [], link: [] },
+    content_format: 'json',
+    content: {
+      element: 'node',
+      content: '<p>Form response received, submit was successful!</p>',
+    },
+    page_layout: 'default',
+    local_tasks: [],
+  }
+})

--- a/src/module.ts
+++ b/src/module.ts
@@ -61,6 +61,8 @@ export interface ModuleOptions {
   serverLogLevel?: boolean | 'info' | 'error'
   disableFormHandler?: boolean | string[]
   enableComponentPreview?: boolean
+  /** Extra Drupal JS URLs (substring match) the library loader must not load. */
+  skipLibraryScripts?: string[]
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -88,6 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
     serverLogLevel: 'info',
     disableFormHandler: false,
     enableComponentPreview: true,
+    skipLibraryScripts: [],
   },
   async setup(options, nuxt) {
     const nuxtOptions = nuxt.options as NuxtOptionsWithDrupalCe

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -108,50 +108,6 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
 }
 
 /**
- * Rewrites root-relative URLs in the AJAX section of drupalSettings to absolute
- * backend URLs, mutating `settings` in place.
- *
- * Core builds a form element's `#ajax` url from `Url::fromRoute('<current>')`,
- * which serialises to a root-relative path (e.g. `/form/x?…`). On a decoupled
- * page that resolves against the *frontend* origin, so `Drupal.ajax` would POST
- * to the frontend, which runs no Drupal, and the request never reaches the
- * backend (the managed_file upload symptom: clicking "Upload" produces no
- * request at all). Rewriting the url — and the optional progress url — against
- * the backend base URL points it at the backend, which serves the frontend's
- * origin with credentialed CORS.
- *
- * `ajaxTrustedUrl` is re-keyed to match: `ajax.js` throws "The callback URL is
- * not local and not trusted" for a cross-origin url absent from that map, and
- * trusted urls also bypass its multipart-upload response-token check. Idempotent
- * — an already-absolute url passes through `absoluteUrl` unchanged.
- */
-function absolutizeAjaxSettings(settings: Record<string, unknown>, baseUrl: string): void {
-  const ajax = settings.ajax
-  if (isPlainObject(ajax)) {
-    for (const entry of Object.values(ajax)) {
-      if (!isPlainObject(entry)) {
-        continue
-      }
-      if (typeof entry.url === 'string') {
-        entry.url = absoluteUrl(entry.url, baseUrl)
-      }
-      const progress = entry.progress
-      if (isPlainObject(progress) && typeof progress.url === 'string') {
-        progress.url = absoluteUrl(progress.url, baseUrl)
-      }
-    }
-  }
-  const trusted = settings.ajaxTrustedUrl
-  if (isPlainObject(trusted)) {
-    const rekeyed: Record<string, unknown> = {}
-    for (const [url, value] of Object.entries(trusted)) {
-      rekeyed[absoluteUrl(url, baseUrl)] = value
-    }
-    settings.ajaxTrustedUrl = rekeyed
-  }
-}
-
-/**
  * Runs Drupal.attachBehaviors on the document, if Drupal has loaded.
  *
  * Safe to call repeatedly: Drupal's `once()` prevents re-processing.
@@ -181,9 +137,6 @@ export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: strin
     try {
       const win = window as unknown as { drupalSettings?: Record<string, unknown> }
       win.drupalSettings = deepMerge(win.drupalSettings ?? {}, JSON.parse(library.drupalSettings))
-      // The merged settings carry the backend's root-relative AJAX urls; point
-      // them at the backend so Drupal.ajax reaches it instead of the frontend.
-      absolutizeAjaxSettings(win.drupalSettings, baseUrl)
     }
     catch (error) {
       console.error('[drupal-library] invalid drupalSettings', error)

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -51,6 +51,22 @@ function absoluteUrl(url: string, baseUrl: string): string {
 }
 
 /**
+ * Whether to skip loading a given Drupal JS file.
+ *
+ * `core/misc/drupalSettingsLoader.js` unconditionally resets
+ * `window.drupalSettings` to `{}` and repopulates it only from a
+ * `drupal-settings-json` element, which a CE-rendered page never emits. On the
+ * decoupled frontend we own drupalSettings ourselves (see seedDrupalSettings),
+ * so running it would just wipe our merged settings. Skip it.
+ *
+ * @param url - Root-relative or absolute JS URL from the backend.
+ * @returns True if the file should not be loaded.
+ */
+function skipScript(url: string): boolean {
+  return /\/core\/misc\/drupalSettingsLoader\.js(\?|$)/.test(url)
+}
+
+/**
  * Injects a `<script>` for the given source, once.
  *
  * Already-loaded sources resolve immediately. A load error resolves (not
@@ -110,16 +126,11 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
 /**
  * Seeds drupalSettings for the decoupled page.
  *
- * Merges the backend's settings into `window.drupalSettings` and writes them to
- * the `drupal-settings-json` `<script>` element that core's
- * `drupalSettingsLoader.js` reads. That element is essential:
- * `drupalSettingsLoader.js` unconditionally resets `window.drupalSettings` to
- * `{}` and only repopulates it from that element, so a plain in-memory merge is
- * wiped the moment core JS runs and behaviours (e.g. AJAX, which builds its
- * instances from `drupalSettings.ajax`) then see empty settings. Writing the
- * full merged settings to the element keeps them intact whenever
- * `drupalSettingsLoader.js` runs; the in-memory merge covers the window before
- * it does, and the case where it has already loaded and will not run again.
+ * Merges the backend's settings into `window.drupalSettings` in memory. This is
+ * the sole owner of `drupalSettings` on the decoupled frontend: core's
+ * `drupalSettingsLoader.js` (which would reset the global to `{}` and repopulate
+ * it from a `drupal-settings-json` element that a CE page never emits) is
+ * skipped at load time (see skipScript), so nothing wipes this merge.
  *
  * @param json - The backend's merged drupalSettings as a JSON string.
  */
@@ -130,21 +141,15 @@ function seedDrupalSettings(json: string): void {
     // ajaxPageState must exist for core's ajax.js: Drupal.Ajax.beforeSerialize()
     // reads drupalSettings.ajaxPageState.{theme,theme_token,libraries} and throws
     // (swallowed by Ajax.execute()) if it is absent, so no request is ever sent.
-    // The backend omits it from a CE-rendered form; default it so the first
-    // request works, then the AJAX response's own ajaxPageState takes over.
+    // The backend omits it from a CE-rendered form; a minimal stub is enough —
+    // an empty theme resolves to the default theme on the backend, and empty
+    // libraries only means the first AJAX response re-sends its (aggregated)
+    // assets. We deliberately do not track loaded libraries here: the frontend
+    // loads them through the drupal-library components, not this mechanism.
     if (!merged.ajaxPageState) {
       merged.ajaxPageState = { theme: '', theme_token: null, libraries: '' }
     }
     win.drupalSettings = merged
-    const selector = 'script[data-drupal-selector="drupal-settings-json"]'
-    let el = document.querySelector<HTMLScriptElement>(selector)
-    if (!el) {
-      el = document.createElement('script')
-      el.type = 'application/json'
-      el.dataset.drupalSelector = 'drupal-settings-json'
-      document.head.appendChild(el)
-    }
-    el.textContent = JSON.stringify(merged)
   }
   catch (error) {
     console.error('[drupal-library] invalid drupalSettings', error)
@@ -180,7 +185,9 @@ export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: strin
     seedDrupalSettings(library.drupalSettings)
   }
 
-  const urls = (library.js ?? []).map(file => absoluteUrl(file.url, baseUrl))
+  const urls = (library.js ?? [])
+    .filter(file => !skipScript(file.url))
+    .map(file => absoluteUrl(file.url, baseUrl))
 
   pending++
   const done = queue

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -152,27 +152,6 @@ function absolutizeAjaxSettings(settings: Record<string, unknown>, baseUrl: stri
 }
 
 /**
- * Injects, once, the single CSS rule that hides `.js-hide` elements.
- *
- * Core ships `.js .js-hide { display: none }` in its `system/base` CSS, which a
- * decoupled frontend deliberately never loads. Without it, elements Drupal marks
- * as JS-only stay visible — e.g. a managed_file element's "Upload" button, which
- * is `js-hide` because its auto-upload behaviour replaces it; left visible,
- * users click it and fall through to a plain submit. `core/drupal`
- * (misc/drupal.init.js) already adds the `js` class to <html>, so the core
- * selector applies as-is once this rule is present.
- */
-function ensureDrupalBaseStyles(): void {
-  if (document.querySelector('style[data-drupal-base-styles]')) {
-    return
-  }
-  const style = document.createElement('style')
-  style.dataset.drupalBaseStyles = ''
-  style.textContent = '.js .js-hide{display:none}'
-  document.head.appendChild(style)
-}
-
-/**
  * Runs Drupal.attachBehaviors on the document, if Drupal has loaded.
  *
  * Safe to call repeatedly: Drupal's `once()` prevents re-processing.
@@ -198,10 +177,6 @@ function attachBehaviors(): void {
  * @returns A promise that settles once this library's files have loaded.
  */
 export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: string): Promise<void> {
-  // Supply the js-hide rule core would have shipped in its (never-loaded) base
-  // CSS, whenever any Drupal library is about to run.
-  ensureDrupalBaseStyles()
-
   if (library.drupalSettings) {
     try {
       const win = window as unknown as { drupalSettings?: Record<string, unknown> }

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -21,6 +21,8 @@ export interface DrupalLibraryJsFile {
 
 /** A resolved Drupal library: its JS files (in load order) and merged settings. */
 export interface DrupalResolvedLibrary {
+  /** The library's fully-qualified name, e.g. `core/drupal.ajax`. */
+  name?: string
   /** The library's JS files, in dependency order. */
   js: DrupalLibraryJsFile[]
   /** Merged drupalSettings as a JSON string (kept opaque so keys survive). */
@@ -29,6 +31,26 @@ export interface DrupalResolvedLibrary {
 
 /** URLs already loaded, so a library shared by several callers loads once. */
 const loadedScripts = new Set<string>()
+
+/**
+ * Fully-qualified names of the Drupal libraries loaded on this page.
+ *
+ * Reported back to Drupal through `drupalSettings.ajaxPageState.libraries` so an
+ * AJAX response (e.g. a managed_file upload) does not re-send `add_css`/`add_js`
+ * for libraries already present — the backend diffs its attachments against this
+ * set. This is a report of what the `<drupal-library-*>` components loaded, not
+ * a mechanism that drives loading.
+ */
+const loadedLibraries = new Set<string>()
+
+/**
+ * Whether we own `ajaxPageState.libraries`.
+ *
+ * A CE-rendered page sends no `ajaxPageState`, so we populate it from
+ * `loadedLibraries`. If a backend ever supplies its own `ajaxPageState`, we
+ * defer to it verbatim and stop managing the field.
+ */
+let manageAjaxLibraries = true
 
 /** Serialises loading so scripts execute in request order across callers. */
 let queue: Promise<void> = Promise.resolve()
@@ -141,19 +163,50 @@ function seedDrupalSettings(json: string): void {
     // ajaxPageState must exist for core's ajax.js: Drupal.Ajax.beforeSerialize()
     // reads drupalSettings.ajaxPageState.{theme,theme_token,libraries} and throws
     // (swallowed by Ajax.execute()) if it is absent, so no request is ever sent.
-    // The backend omits it from a CE-rendered form; a minimal stub is enough —
-    // an empty theme resolves to the default theme on the backend, and empty
-    // libraries only means the first AJAX response re-sends its (aggregated)
-    // assets. We deliberately do not track loaded libraries here: the frontend
-    // loads them through the drupal-library components, not this mechanism.
+    // A CE-rendered form omits it; a minimal stub is enough — an empty theme
+    // resolves to the default theme on the backend. Its `libraries` list is
+    // filled from the loaded set (see reportLoadedLibraries) so the backend
+    // skips re-sending assets already on the page. If a backend ever supplies
+    // its own ajaxPageState, defer to it verbatim.
     if (!merged.ajaxPageState) {
       merged.ajaxPageState = { theme: '', theme_token: null, libraries: '' }
+    }
+    else {
+      manageAjaxLibraries = false
     }
     win.drupalSettings = merged
   }
   catch (error) {
     console.error('[drupal-library] invalid drupalSettings', error)
   }
+}
+
+/**
+ * Reflects the loaded-library set into `drupalSettings.ajaxPageState.libraries`.
+ *
+ * A plain comma-joined list is enough: Drupal's
+ * `UrlHelper::uncompressQueryParameter()` falls back to the raw string when
+ * gzip-inflate fails, so the backend reads the names without any compression. A
+ * non-empty list also avoids the degenerate empty-string entry that otherwise
+ * reaches core's asset resolver and triggers "Undefined array key 1" /
+ * missing-theme warnings while diffing an empty `''` library.
+ *
+ * No-op until drupalSettings has been seeded (seedDrupalSettings creates the
+ * ajaxPageState it writes into) and when a backend owns ajaxPageState itself.
+ */
+function reportLoadedLibraries(): void {
+  if (!manageAjaxLibraries) {
+    return
+  }
+  const win = window as unknown as { drupalSettings?: Record<string, unknown> }
+  const settings = win.drupalSettings
+  if (!settings) {
+    return
+  }
+  if (!settings.ajaxPageState) {
+    settings.ajaxPageState = { theme: '', theme_token: null, libraries: '' }
+  }
+  ;(settings.ajaxPageState as Record<string, unknown>).libraries = [...loadedLibraries].join(',')
 }
 
 /**
@@ -172,18 +225,24 @@ function attachBehaviors(): void {
  * done.
  *
  * `drupalSettings` (if any) is seeded synchronously before any script runs (see
- * seedDrupalSettings) — Drupal core JS expects it to exist. Files are appended
- * to the shared queue so they load after earlier requests; when the queue
- * drains, behaviours attach once.
+ * seedDrupalSettings) — Drupal core JS expects it to exist. The library's name
+ * is recorded and reflected into `ajaxPageState.libraries` (see
+ * reportLoadedLibraries) so the backend skips its assets on later AJAX
+ * responses. Files are appended to the shared queue so they load after earlier
+ * requests; when the queue drains, behaviours attach once.
  *
  * @param library - The resolved library (JS files + optional drupalSettings).
  * @param baseUrl - The Drupal backend base URL for resolving root-relative URLs.
  * @returns A promise that settles once this library's files have loaded.
  */
 export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: string): Promise<void> {
+  if (library.name) {
+    loadedLibraries.add(library.name)
+  }
   if (library.drupalSettings) {
     seedDrupalSettings(library.drupalSettings)
   }
+  reportLoadedLibraries()
 
   const urls = (library.js ?? [])
     .filter(file => !skipScript(file.url))

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -108,6 +108,50 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
 }
 
 /**
+ * Seeds drupalSettings for the decoupled page.
+ *
+ * Merges the backend's settings into `window.drupalSettings` and writes them to
+ * the `drupal-settings-json` `<script>` element that core's
+ * `drupalSettingsLoader.js` reads. That element is essential:
+ * `drupalSettingsLoader.js` unconditionally resets `window.drupalSettings` to
+ * `{}` and only repopulates it from that element, so a plain in-memory merge is
+ * wiped the moment core JS runs and behaviours (e.g. AJAX, which builds its
+ * instances from `drupalSettings.ajax`) then see empty settings. Writing the
+ * full merged settings to the element keeps them intact whenever
+ * `drupalSettingsLoader.js` runs; the in-memory merge covers the window before
+ * it does, and the case where it has already loaded and will not run again.
+ *
+ * @param json - The backend's merged drupalSettings as a JSON string.
+ */
+function seedDrupalSettings(json: string): void {
+  try {
+    const win = window as unknown as { drupalSettings?: Record<string, unknown> }
+    const merged = deepMerge(win.drupalSettings ?? {}, JSON.parse(json))
+    // ajaxPageState must exist for core's ajax.js: Drupal.Ajax.beforeSerialize()
+    // reads drupalSettings.ajaxPageState.{theme,theme_token,libraries} and throws
+    // (swallowed by Ajax.execute()) if it is absent, so no request is ever sent.
+    // The backend omits it from a CE-rendered form; default it so the first
+    // request works, then the AJAX response's own ajaxPageState takes over.
+    if (!merged.ajaxPageState) {
+      merged.ajaxPageState = { theme: '', theme_token: null, libraries: '' }
+    }
+    win.drupalSettings = merged
+    const selector = 'script[data-drupal-selector="drupal-settings-json"]'
+    let el = document.querySelector<HTMLScriptElement>(selector)
+    if (!el) {
+      el = document.createElement('script')
+      el.type = 'application/json'
+      el.dataset.drupalSelector = 'drupal-settings-json'
+      document.head.appendChild(el)
+    }
+    el.textContent = JSON.stringify(merged)
+  }
+  catch (error) {
+    console.error('[drupal-library] invalid drupalSettings', error)
+  }
+}
+
+/**
  * Runs Drupal.attachBehaviors on the document, if Drupal has loaded.
  *
  * Safe to call repeatedly: Drupal's `once()` prevents re-processing.
@@ -122,11 +166,10 @@ function attachBehaviors(): void {
  * Loads a resolved Drupal library, then attaches behaviours once the batch is
  * done.
  *
- * `drupalSettings` (if any) is merged into `window.drupalSettings` synchronously
- * before any script runs — Drupal core JS expects it to exist, and a decoupled
- * page has no settings-json `<script>` for `drupalSettingsLoader.js` to read.
- * Files are appended to the shared queue so they load after earlier requests;
- * when the queue drains, behaviours attach once.
+ * `drupalSettings` (if any) is seeded synchronously before any script runs (see
+ * seedDrupalSettings) — Drupal core JS expects it to exist. Files are appended
+ * to the shared queue so they load after earlier requests; when the queue
+ * drains, behaviours attach once.
  *
  * @param library - The resolved library (JS files + optional drupalSettings).
  * @param baseUrl - The Drupal backend base URL for resolving root-relative URLs.
@@ -134,13 +177,7 @@ function attachBehaviors(): void {
  */
 export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: string): Promise<void> {
   if (library.drupalSettings) {
-    try {
-      const win = window as unknown as { drupalSettings?: Record<string, unknown> }
-      win.drupalSettings = deepMerge(win.drupalSettings ?? {}, JSON.parse(library.drupalSettings))
-    }
-    catch (error) {
-      console.error('[drupal-library] invalid drupalSettings', error)
-    }
+    seedDrupalSettings(library.drupalSettings)
   }
 
   const urls = (library.js ?? []).map(file => absoluteUrl(file.url, baseUrl))

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -108,6 +108,71 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
 }
 
 /**
+ * Rewrites root-relative URLs in the AJAX section of drupalSettings to absolute
+ * backend URLs, mutating `settings` in place.
+ *
+ * Core builds a form element's `#ajax` url from `Url::fromRoute('<current>')`,
+ * which serialises to a root-relative path (e.g. `/form/x?…`). On a decoupled
+ * page that resolves against the *frontend* origin, so `Drupal.ajax` would POST
+ * to the frontend, which runs no Drupal, and the request never reaches the
+ * backend (the managed_file upload symptom: clicking "Upload" produces no
+ * request at all). Rewriting the url — and the optional progress url — against
+ * the backend base URL points it at the backend, which serves the frontend's
+ * origin with credentialed CORS.
+ *
+ * `ajaxTrustedUrl` is re-keyed to match: `ajax.js` throws "The callback URL is
+ * not local and not trusted" for a cross-origin url absent from that map, and
+ * trusted urls also bypass its multipart-upload response-token check. Idempotent
+ * — an already-absolute url passes through `absoluteUrl` unchanged.
+ */
+function absolutizeAjaxSettings(settings: Record<string, unknown>, baseUrl: string): void {
+  const ajax = settings.ajax
+  if (isPlainObject(ajax)) {
+    for (const entry of Object.values(ajax)) {
+      if (!isPlainObject(entry)) {
+        continue
+      }
+      if (typeof entry.url === 'string') {
+        entry.url = absoluteUrl(entry.url, baseUrl)
+      }
+      const progress = entry.progress
+      if (isPlainObject(progress) && typeof progress.url === 'string') {
+        progress.url = absoluteUrl(progress.url, baseUrl)
+      }
+    }
+  }
+  const trusted = settings.ajaxTrustedUrl
+  if (isPlainObject(trusted)) {
+    const rekeyed: Record<string, unknown> = {}
+    for (const [url, value] of Object.entries(trusted)) {
+      rekeyed[absoluteUrl(url, baseUrl)] = value
+    }
+    settings.ajaxTrustedUrl = rekeyed
+  }
+}
+
+/**
+ * Injects, once, the single CSS rule that hides `.js-hide` elements.
+ *
+ * Core ships `.js .js-hide { display: none }` in its `system/base` CSS, which a
+ * decoupled frontend deliberately never loads. Without it, elements Drupal marks
+ * as JS-only stay visible — e.g. a managed_file element's "Upload" button, which
+ * is `js-hide` because its auto-upload behaviour replaces it; left visible,
+ * users click it and fall through to a plain submit. `core/drupal`
+ * (misc/drupal.init.js) already adds the `js` class to <html>, so the core
+ * selector applies as-is once this rule is present.
+ */
+function ensureDrupalBaseStyles(): void {
+  if (document.querySelector('style[data-drupal-base-styles]')) {
+    return
+  }
+  const style = document.createElement('style')
+  style.dataset.drupalBaseStyles = ''
+  style.textContent = '.js .js-hide{display:none}'
+  document.head.appendChild(style)
+}
+
+/**
  * Runs Drupal.attachBehaviors on the document, if Drupal has loaded.
  *
  * Safe to call repeatedly: Drupal's `once()` prevents re-processing.
@@ -133,10 +198,17 @@ function attachBehaviors(): void {
  * @returns A promise that settles once this library's files have loaded.
  */
 export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: string): Promise<void> {
+  // Supply the js-hide rule core would have shipped in its (never-loaded) base
+  // CSS, whenever any Drupal library is about to run.
+  ensureDrupalBaseStyles()
+
   if (library.drupalSettings) {
     try {
       const win = window as unknown as { drupalSettings?: Record<string, unknown> }
       win.drupalSettings = deepMerge(win.drupalSettings ?? {}, JSON.parse(library.drupalSettings))
+      // The merged settings carry the backend's root-relative AJAX urls; point
+      // them at the backend so Drupal.ajax reaches it instead of the frontend.
+      absolutizeAjaxSettings(win.drupalSettings, baseUrl)
     }
     catch (error) {
       console.error('[drupal-library] invalid drupalSettings', error)

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -33,24 +33,12 @@ export interface DrupalResolvedLibrary {
 const loadedScripts = new Set<string>()
 
 /**
- * Fully-qualified names of the Drupal libraries loaded on this page.
- *
- * Reported back to Drupal through `drupalSettings.ajaxPageState.libraries` so an
- * AJAX response (e.g. a managed_file upload) does not re-send `add_css`/`add_js`
- * for libraries already present — the backend diffs its attachments against this
- * set. This is a report of what the `<drupal-library-*>` components loaded, not
- * a mechanism that drives loading.
+ * Fully-qualified names of the Drupal libraries loaded on this page, reported
+ * through `drupalSettings.ajaxPageState.libraries` so an AJAX response (e.g. a
+ * managed_file upload) does not re-send `add_css`/`add_js` for libraries already
+ * present. A report of what the components loaded, not a driver of loading.
  */
 const loadedLibraries = new Set<string>()
-
-/**
- * Whether we own `ajaxPageState.libraries`.
- *
- * A CE-rendered page sends no `ajaxPageState`, so we populate it from
- * `loadedLibraries`. If a backend ever supplies its own `ajaxPageState`, we
- * defer to it verbatim and stop managing the field.
- */
-let manageAjaxLibraries = true
 
 /** Serialises loading so scripts execute in request order across callers. */
 let queue: Promise<void> = Promise.resolve()
@@ -75,17 +63,21 @@ function absoluteUrl(url: string, baseUrl: string): string {
 /**
  * Whether to skip loading a given Drupal JS file.
  *
- * `core/misc/drupalSettingsLoader.js` unconditionally resets
+ * `core/misc/drupalSettingsLoader.js` is always skipped: it resets
  * `window.drupalSettings` to `{}` and repopulates it only from a
- * `drupal-settings-json` element, which a CE-rendered page never emits. On the
- * decoupled frontend we own drupalSettings ourselves (see seedDrupalSettings),
- * so running it would just wipe our merged settings. Skip it.
+ * `drupal-settings-json` element a CE page never emits, so it would wipe our
+ * merged settings (see seedDrupalSettings). Sites can skip further files via the
+ * `skipLibraryScripts` module option (substring match).
  *
  * @param url - Root-relative or absolute JS URL from the backend.
+ * @param extraSkip - Site-configured URL substrings to skip.
  * @returns True if the file should not be loaded.
  */
-function skipScript(url: string): boolean {
-  return /\/core\/misc\/drupalSettingsLoader\.js(\?|$)/.test(url)
+function skipScript(url: string, extraSkip: string[]): boolean {
+  if (/\/core\/misc\/drupalSettingsLoader\.js(\?|$)/.test(url)) {
+    return true
+  }
+  return extraSkip.some(pattern => url.includes(pattern))
 }
 
 /**
@@ -160,19 +152,10 @@ function seedDrupalSettings(json: string): void {
   try {
     const win = window as unknown as { drupalSettings?: Record<string, unknown> }
     const merged = deepMerge(win.drupalSettings ?? {}, JSON.parse(json))
-    // ajaxPageState must exist for core's ajax.js: Drupal.Ajax.beforeSerialize()
-    // reads drupalSettings.ajaxPageState.{theme,theme_token,libraries} and throws
-    // (swallowed by Ajax.execute()) if it is absent, so no request is ever sent.
-    // A CE-rendered form omits it; a minimal stub is enough — an empty theme
-    // resolves to the default theme on the backend. Its `libraries` list is
-    // filled from the loaded set (see reportLoadedLibraries) so the backend
-    // skips re-sending assets already on the page. If a backend ever supplies
-    // its own ajaxPageState, defer to it verbatim.
+    // core ajax.js reads ajaxPageState.{theme,theme_token,libraries}; a CE form
+    // omits it, so default to an empty stub so dependent callers have something.
     if (!merged.ajaxPageState) {
       merged.ajaxPageState = { theme: '', theme_token: null, libraries: '' }
-    }
-    else {
-      manageAjaxLibraries = false
     }
     win.drupalSettings = merged
   }
@@ -182,20 +165,13 @@ function seedDrupalSettings(json: string): void {
 }
 
 /**
- * Reflects the loaded-library set into `drupalSettings.ajaxPageState.libraries`.
- *
- * A plain comma-joined list is enough: Drupal's
- * `UrlHelper::uncompressQueryParameter()` falls back to the raw string when
- * gzip-inflate fails, so the backend reads the names without any compression. A
- * non-empty list also avoids the degenerate empty-string entry that otherwise
- * reaches core's asset resolver and triggers "Undefined array key 1" /
- * missing-theme warnings while diffing an empty `''` library.
- *
- * No-op until drupalSettings has been seeded (seedDrupalSettings creates the
- * ajaxPageState it writes into) and when a backend owns ajaxPageState itself.
+ * Reflects the loaded-library set into `drupalSettings.ajaxPageState.libraries`
+ * (a plain comma-joined list Drupal reads uncompressed) so the backend skips
+ * assets already on the page. No-op when no library names were given or before
+ * drupalSettings has been seeded.
  */
 function reportLoadedLibraries(): void {
-  if (!manageAjaxLibraries) {
+  if (loadedLibraries.size === 0) {
     return
   }
   const win = window as unknown as { drupalSettings?: Record<string, unknown> }
@@ -221,21 +197,15 @@ function attachBehaviors(): void {
 }
 
 /**
- * Loads a resolved Drupal library, then attaches behaviours once the batch is
- * done.
+ * Loads a resolved Drupal library's JS files (in dependency order), then
+ * attaches behaviours once the current batch drains.
  *
- * `drupalSettings` (if any) is seeded synchronously before any script runs (see
- * seedDrupalSettings) — Drupal core JS expects it to exist. The library's name
- * is recorded and reflected into `ajaxPageState.libraries` (see
- * reportLoadedLibraries) so the backend skips its assets on later AJAX
- * responses. Files are appended to the shared queue so they load after earlier
- * requests; when the queue drains, behaviours attach once.
- *
- * @param library - The resolved library (JS files + optional drupalSettings).
+ * @param library - The resolved library (name, JS files, optional drupalSettings).
  * @param baseUrl - The Drupal backend base URL for resolving root-relative URLs.
+ * @param skipScripts - Site-configured URL substrings not to load.
  * @returns A promise that settles once this library's files have loaded.
  */
-export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: string): Promise<void> {
+export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: string, skipScripts: string[] = []): Promise<void> {
   if (library.name) {
     loadedLibraries.add(library.name)
   }
@@ -245,7 +215,7 @@ export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: strin
   reportLoadedLibraries()
 
   const urls = (library.js ?? [])
-    .filter(file => !skipScript(file.url))
+    .filter(file => !skipScript(file.url, skipScripts))
     .map(file => absoluteUrl(file.url, baseUrl))
 
   pending++

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -677,7 +677,7 @@ export const useDrupalCe = () => {
    * files (in dependency order) and merged drupalSettings on the corresponding
    * <drupal-library-*> custom element; this just loads them.
    *
-   * @param library The resolved library ({ js, drupalSettings }) from the
+   * @param library The resolved library ({ name, js, drupalSettings }) from the
    *   backend-generated <drupal-library-*> element.
    * @returns Promise settling once the library's JS has loaded (client-side);
    *   resolves immediately on the server.

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -687,7 +687,7 @@ export const useDrupalCe = () => {
       return
     }
     const { loadDrupalLibrary } = await (drupalLibraryLoaderPromise ??= import('./drupalLibraryLoader'))
-    await loadDrupalLibrary(library, getDrupalBaseUrl())
+    await loadDrupalLibrary(library, getDrupalBaseUrl(), config.skipLibraryScripts ?? [])
   }
 
   return {

--- a/src/runtime/server/middleware/drupalFormHandler.ts
+++ b/src/runtime/server/middleware/drupalFormHandler.ts
@@ -1,6 +1,19 @@
-import { defineEventHandler, readFormData } from 'h3'
+import { defineEventHandler, readFormData, setResponseStatus, setResponseHeader } from 'h3'
 import { getDrupalBaseUrl, headersToRecord } from '../../composables/useDrupalCe/server'
 import { useRuntimeConfig } from '#imports'
+
+/**
+ * Response headers that must not be copied verbatim when a proxied Drupal AJAX
+ * response is returned. The body is re-serialised on the way out, so a copied
+ * content-length / content-encoding would be wrong, and the rest are hop-by-hop.
+ */
+const AJAX_HOP_BY_HOP_HEADERS = new Set([
+  'content-length',
+  'content-encoding',
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+])
 
 export default defineEventHandler(async (event) => {
   const { disableFormHandler } = useRuntimeConfig().drupalCe
@@ -12,76 +25,114 @@ export default defineEventHandler(async (event) => {
     return
   }
 
-  if (event.node.req.method === 'POST') {
-    const routesToBypass = Array.isArray(disableFormHandler) ? disableFormHandler : []
+  if (event.node.req.method !== 'POST') {
+    return
+  }
 
-    if (routesToBypass.length) {
-      // Remove query parameters from the URL.
-      const currentPath = event.node.req.url?.split('?')[0] || '';
-      const shouldBypass = routesToBypass.some(route => {
-        const routeFormats = [
-          route,
-          '/api/drupal-ce' + route,
-          ceApiEndpoint + route
-        ];
-        return routeFormats.some(format => format === currentPath);
-      });
+  const routesToBypass = Array.isArray(disableFormHandler) ? disableFormHandler : []
+  if (routesToBypass.length) {
+    const shouldBypass = routesToBypass.some(route => {
+      const routeFormats = [
+        route,
+        '/api/drupal-ce' + route,
+        ceApiEndpoint + route,
+      ]
+      return routeFormats.some(format => format === currentPath)
+    })
 
-      if (shouldBypass) {
-        return;
-      }
-    }
-    
-    const contentType = event.node.req.headers['content-type'] || ''
-    if (!contentType.includes('multipart/form-data') && !contentType.includes('application/x-www-form-urlencoded') || event.node.req.headers['x-form-processed']) {
+    if (shouldBypass) {
       return
     }
+  }
 
-    const formData = await readFormData(event)
+  const contentType = event.node.req.headers['content-type'] || ''
+  if (!contentType.includes('multipart/form-data') && !contentType.includes('application/x-www-form-urlencoded') || event.node.req.headers['x-form-processed']) {
+    return
+  }
 
-    if (formData) {
-      const targetUrl = event.node.req.url
-      // Forward configured proxy headers (e.g. cookie) from the original request.
-      const proxyHeaders: Record<string, string> = {}
-      if (Array.isArray(fetchProxyHeaders)) {
-        for (const name of fetchProxyHeaders) {
-          const value = event.node.req.headers[name.toLowerCase()]
-          if (value) {
-            proxyHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(', ') : value
-          }
-        }
-      }
-      const response = await $fetch.raw(getDrupalBaseUrl() + ceApiEndpoint + targetUrl, {
-        method: 'POST',
-        body: formData,
-        headers: {
-          ...fetchOptions?.headers,
-          ...proxyHeaders,
-          'x-form-processed': 'true',
-        },
-      }).catch((error) => {
-        event.context.drupalCeCustomPageResponse = {
-          error: {
-            data: error,
-            statusCode: error.statusCode || 400,
-            message: error.message || 'Error when POSTing form data (drupalFormHandler).',
-          },
-        }
-      })
+  const formData = await readFormData(event)
 
-      if (response) {
-        event.context.drupalCeCustomPageResponse = {
-          _data: response._data,
-          headers: headersToRecord(response.headers),
-        }
+  if (!formData) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Bad Request',
+      message: 'POST requests without form data are not supported (drupalFormHandler).',
+    })
+  }
+
+  const targetUrl = event.node.req.url
+
+  // Drupal AJAX form requests (e.g. a managed_file upload / remove button) POST
+  // to the form's own path with ?ajax_form=1. Core builds that URL root-relative
+  // (Url::fromRoute('<current>')), so in the decoupled frontend it lands on this
+  // origin — and thus on this proxy — rather than cross-origin on the backend.
+  // Such a request expects Drupal's AJAX command response (JSON) back verbatim so
+  // ajax.js can apply the commands; the SSR page-render flow below is only right
+  // for a full (non-AJAX) form submit.
+  const isAjaxForm = new URLSearchParams(targetUrl?.split('?')[1] || '').has('ajax_form')
+
+  // Forward configured proxy headers (e.g. cookie) from the original request.
+  const proxyHeaders: Record<string, string> = {}
+  if (Array.isArray(fetchProxyHeaders)) {
+    for (const name of fetchProxyHeaders) {
+      const value = event.node.req.headers[name.toLowerCase()]
+      if (value) {
+        proxyHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(', ') : value
       }
     }
-    else {
+  }
+
+  const response = await $fetch.raw(getDrupalBaseUrl() + ceApiEndpoint + targetUrl, {
+    method: 'POST',
+    body: formData,
+    headers: {
+      ...fetchOptions?.headers,
+      ...proxyHeaders,
+      'x-form-processed': 'true',
+    },
+  }).catch((error) => {
+    if (isAjaxForm) {
+      // Surface the failure to ajax.js as an HTTP error instead of routing it
+      // through the page-render error handling.
       throw createError({
-        statusCode: 400,
-        statusMessage: 'Bad Request',
-        message: 'POST requests without form data are not supported (drupalFormHandler).',
+        statusCode: error.statusCode || 502,
+        statusMessage: error.statusMessage || 'Bad Gateway',
+        message: error.message || 'Error when proxying AJAX form request (drupalFormHandler).',
       })
+    }
+    event.context.drupalCeCustomPageResponse = {
+      error: {
+        data: error,
+        statusCode: error.statusCode || 400,
+        message: error.message || 'Error when POSTing form data (drupalFormHandler).',
+      },
+    }
+  })
+
+  if (isAjaxForm) {
+    if (response) {
+      setResponseStatus(event, response.status)
+      // Pass the backend response headers through so ajax.js sees the
+      // X-Drupal-Ajax-Token verification header (and Set-Cookie), then return
+      // the AJAX command payload directly — short-circuiting the SSR render.
+      for (const [name, value] of response.headers.entries()) {
+        if (!AJAX_HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+          setResponseHeader(event, name, value)
+        }
+      }
+      const setCookies = response.headers.getSetCookie?.() ?? []
+      if (setCookies.length > 1) {
+        setResponseHeader(event, 'set-cookie', setCookies)
+      }
+      return response._data
+    }
+    return
+  }
+
+  if (response) {
+    event.context.drupalCeCustomPageResponse = {
+      _data: response._data,
+      headers: headersToRecord(response.headers),
     }
   }
 })

--- a/src/runtime/server/middleware/drupalFormHandler.ts
+++ b/src/runtime/server/middleware/drupalFormHandler.ts
@@ -1,22 +1,17 @@
-import { defineEventHandler, readFormData, setResponseStatus, setResponseHeader } from 'h3'
+import { defineEventHandler, readFormData, setResponseStatus, appendResponseHeader } from 'h3'
 import { getDrupalBaseUrl, headersToRecord } from '../../composables/useDrupalCe/server'
 import { useRuntimeConfig } from '#imports'
 
 /**
- * Response headers that must not be copied verbatim when a proxied Drupal AJAX
- * response is returned. The body is re-serialised on the way out, so a copied
- * content-length / content-encoding would be wrong, and the rest are hop-by-hop.
+ * The X-Drupal-Ajax-Token verification header is always passed through on a
+ * proxied AJAX form response: ajax.js rejects an AJAX command response that
+ * lacks it. Every other response header obeys the configured passThroughHeaders
+ * allow-list.
  */
-const AJAX_HOP_BY_HOP_HEADERS = new Set([
-  'content-length',
-  'content-encoding',
-  'transfer-encoding',
-  'connection',
-  'keep-alive',
-])
+const AJAX_REQUIRED_HEADER = 'x-drupal-ajax-token'
 
 export default defineEventHandler(async (event) => {
-  const { disableFormHandler } = useRuntimeConfig().drupalCe
+  const { disableFormHandler, passThroughHeaders } = useRuntimeConfig().drupalCe
   const { ceApiEndpoint, fetchProxyHeaders, fetchOptions } = useRuntimeConfig().public.drupalCe
 
   // Skip API proxy routes - we don't want to handle them here.
@@ -112,17 +107,24 @@ export default defineEventHandler(async (event) => {
   if (isAjaxForm) {
     if (response) {
       setResponseStatus(event, response.status)
-      // Pass the backend response headers through so ajax.js sees the
-      // X-Drupal-Ajax-Token verification header (and Set-Cookie), then return
-      // the AJAX command payload directly — short-circuiting the SSR render.
-      for (const [name, value] of response.headers.entries()) {
-        if (!AJAX_HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
-          setResponseHeader(event, name, value)
+      // Obey the configured passThroughHeaders allow-list (same setting the SSR
+      // page-render path uses), plus the X-Drupal-Ajax-Token header ajax.js
+      // requires, then return the AJAX command payload directly — short-circuiting
+      // the SSR render.
+      const allowed = new Set(
+        [...(Array.isArray(passThroughHeaders) ? passThroughHeaders : []), AJAX_REQUIRED_HEADER]
+          .map(name => name.toLowerCase()),
+      )
+      const responseHeaders = headersToRecord(response.headers)
+      for (const [name, value] of Object.entries(responseHeaders)) {
+        if (!allowed.has(name.toLowerCase())) {
+          continue
         }
-      }
-      const setCookies = response.headers.getSetCookie?.() ?? []
-      if (setCookies.length > 1) {
-        setResponseHeader(event, 'set-cookie', setCookies)
+        // headersToRecord keeps multiple Set-Cookie values as an array; append
+        // each one so they are not comma-joined into a single invalid header.
+        for (const v of Array.isArray(value) ? value : [value]) {
+          appendResponseHeader(event, name, v)
+        }
       }
       return response._data
     }

--- a/test/e2e/drupalFormHandler.test.ts
+++ b/test/e2e/drupalFormHandler.test.ts
@@ -114,6 +114,10 @@ describe('Drupal form handler', async () => {
     expect(response.headers.get('content-type')).toContain('application/json')
     // The verification header must survive the proxy or ajax.js rejects the response.
     expect(response.headers.get('x-drupal-ajax-token')).toBe('1')
+    // Other response headers obey the configured passThroughHeaders allow-list:
+    // an allow-listed one passes, a non-listed one is dropped.
+    expect(response.headers.get('x-drupal-cache')).toBe('MISS')
+    expect(response.headers.get('x-custom-debug')).toBe(null)
 
     const data = await response.json()
     expect(Array.isArray(data)).toBe(true)

--- a/test/e2e/drupalFormHandler.test.ts
+++ b/test/e2e/drupalFormHandler.test.ts
@@ -96,6 +96,47 @@ describe('Drupal form handler', async () => {
     expect(content).toContain('test_session=abc123')
   }, 15000)
 
+  it('proxies an ?ajax_form=1 upload and returns the raw AJAX command response', async () => {
+    // A managed_file upload button POSTs multipart to the form path with
+    // ?ajax_form=1. The middleware must proxy it and return Drupal's AJAX command
+    // JSON verbatim (with the X-Drupal-Ajax-Token header) instead of rendering an
+    // SSR page, so core's ajax.js can apply the commands.
+    const formData = new FormData()
+    formData.append('files[speisekarte]', new Blob(['dummy'], { type: 'text/plain' }), 'menu.txt')
+    formData.append('form_id', 'upload')
+
+    const response = await fetch('http://127.0.0.1:3012/form/upload?ajax_form=1&_wrapper_format=drupal_ajax', {
+      method: 'POST',
+      body: formData,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    // The verification header must survive the proxy or ajax.js rejects the response.
+    expect(response.headers.get('x-drupal-ajax-token')).toBe('1')
+
+    const data = await response.json()
+    expect(Array.isArray(data)).toBe(true)
+    expect(data[0].command).toBe('insert')
+    expect(data[0].selector).toBe('#edit-speisekarte-wrapper')
+  }, 15000)
+
+  it('a non-ajax POST to the same route still renders a page (not raw AJAX)', async () => {
+    const formData = new FormData()
+    formData.append('form_id', 'upload')
+
+    const response = await fetch('http://127.0.0.1:3012/form/upload', {
+      method: 'POST',
+      body: formData,
+      headers: { accept: 'text/html' },
+    })
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    // The full-submit path goes through the SSR page render, not the raw proxy.
+    expect(text).toContain('Form response received, submit was successful!')
+  }, 15000)
+
   it('form handler is bypassed with not matching content-type header', async () => {
     const page = await createPage('/form/custom')
     const name = page.locator('input[name="name"]')

--- a/test/nuxt/drupal-library--default.test.ts
+++ b/test/nuxt/drupal-library--default.test.ts
@@ -1,48 +1,37 @@
 // @vitest-environment nuxt
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
-import { defineComponent } from 'vue'
-import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
 import DrupalLibraryDefault from '../../playground/components/global/drupal-library--default.vue'
 
-// Mock the actual loader so the component test stays DOM-side-effect free; the
-// loader's own behaviour is covered by drupalLibraryLoader.test.ts.
-const { loadDrupalLibrary } = vi.hoisted(() => ({ loadDrupalLibrary: vi.fn().mockResolvedValue(undefined) }))
-vi.mock('../../src/runtime/composables/useDrupalCe/drupalLibraryLoader', () => ({ loadDrupalLibrary }))
+// Stub the composable's loadLibrary so the test stays DOM-side-effect free and
+// asserts only what the component forwards; the loader's own behaviour is
+// covered by drupalLibraryLoader.test.ts.
+const loadLibrary = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+mockNuxtImport('useDrupalCe', () => () => ({ loadLibrary }))
 
 describe('drupal-library--default custom element', () => {
-  beforeEach(() => loadDrupalLibrary.mockClear())
+  beforeEach(() => loadLibrary.mockClear())
 
-  const data = {
-    element: 'drupal-library-core-drupal-states',
+  const props = {
     library: 'core/drupal.states',
     js: [{ url: '/core/misc/states.js?v=1' }],
     drupalSettings: '{"my_module":{"some_key":"value"}}',
   }
 
-  const createComponent = (d: Record<string, unknown> = data) => defineComponent({
-    components: { 'drupal-library-core-drupal-states': DrupalLibraryDefault },
-    setup() {
-      const { renderCustomElements } = useDrupalCe()
-      return { component: renderCustomElements(d) }
-    },
-    template: '<component :is="component" />',
-  })
-
   it('is renderless — emits no markup', async () => {
-    const wrapper = await mountSuspended(createComponent())
-    // Only a comment placeholder for the null render, no elements.
+    const wrapper = await mountSuspended(DrupalLibraryDefault, { props })
     expect(wrapper.html().replace(/<!--.*?-->/gs, '').trim()).toBe('')
   })
 
-  it('loads the resolved library on mount', async () => {
-    await mountSuspended(createComponent())
+  it('forwards its props (incl. the library name) to loadLibrary on mount', async () => {
+    await mountSuspended(DrupalLibraryDefault, { props })
     await flushPromises()
-    expect(loadDrupalLibrary).toHaveBeenCalledTimes(1)
-    expect(loadDrupalLibrary.mock.calls[0]![0]).toEqual({
-      js: data.js,
-      drupalSettings: data.drupalSettings,
+    expect(loadLibrary).toHaveBeenCalledTimes(1)
+    expect(loadLibrary).toHaveBeenCalledWith({
+      name: props.library,
+      js: props.js,
+      drupalSettings: props.drupalSettings,
     })
   })
 })

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -81,20 +81,27 @@ describe('drupalLibraryLoader', () => {
       .toEqual({ my_module: { some_key: 'value' }, ajaxPageState: { theme: '', theme_token: null, libraries: '' } })
   })
 
-  it('writes a drupal-settings-json <script> so core drupalSettingsLoader.js repopulates instead of wiping settings', async () => {
+  it('skips core drupalSettingsLoader.js so it cannot wipe the in-memory settings', async () => {
+    // core/misc/drupalSettingsLoader.js resets window.drupalSettings to {} and
+    // only repopulates it from a drupal-settings-json element that a CE page
+    // never emits. Loading it would drop the AJAX settings (and thus the
+    // managed_file upload's Drupal.ajax instance), so it must not be injected.
     await loadDrupalLibrary(
-      { js: [{ url: '/core/misc/drupalSettingsLoader.js' }], drupalSettings: '{"ajax":{"edit-x":{"url":"/form/x?ajax_form=1"}}}' },
+      {
+        js: [
+          { url: '/core/misc/drupalSettingsLoader.js?v=11.4.5' },
+          { url: '/core/misc/drupal.js?v=1' },
+        ],
+        drupalSettings: '{"ajax":{"edit-x":{"url":"/form/x?ajax_form=1"}}}',
+      },
       'http://backend',
     )
-    // core/misc/drupalSettingsLoader.js resets window.drupalSettings to {} and
-    // only repopulates it from this element; without it the AJAX settings (and
-    // thus the managed_file upload's Drupal.ajax instance) are lost.
-    const el = injected.find(s => s.type === 'application/json' && s.dataset.drupalSelector === 'drupal-settings-json')
-    expect(el).toBeDefined()
-    expect(JSON.parse(el!.textContent!)).toEqual({
-      ajax: { 'edit-x': { url: '/form/x?ajax_form=1' } },
-      ajaxPageState: { theme: '', theme_token: null, libraries: '' },
-    })
+    expect(injected.map(s => s.src)).toEqual(['http://backend/core/misc/drupal.js?v=1'])
+    expect((window as unknown as { drupalSettings: Record<string, unknown> }).drupalSettings)
+      .toEqual({
+        ajax: { 'edit-x': { url: '/form/x?ajax_form=1' } },
+        ajaxPageState: { theme: '', theme_token: null, libraries: '' },
+      })
   })
 
   it('defaults drupalSettings.ajaxPageState so Ajax.beforeSerialize does not throw', async () => {

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -26,12 +26,20 @@ describe('drupalLibraryLoader', () => {
     if (!globalThis.CSS) {
       globalThis.CSS = { escape: (s: string) => s } as unknown as typeof CSS
     }
+    // The DOM persists across tests; drop any base-styles <style> a prior test
+    // injected so the once-guard starts clean.
+    document.head.querySelectorAll('style[data-drupal-base-styles]').forEach(el => el.remove())
 
-    // Mock script insertion: record it and fire onload on the next microtask.
-    vi.spyOn(document.head, 'appendChild').mockImplementation(((el: HTMLScriptElement) => {
-      injected.push(el)
-      queueMicrotask(() => el.onload?.(new Event('load')))
-      return el
+    // Mock script insertion: record scripts and fire onload on the next
+    // microtask. Non-scripts (the injected base-styles <style>) are inserted for
+    // real so the loader's once-guard querySelector can find them.
+    vi.spyOn(document.head, 'appendChild').mockImplementation(((el: HTMLElement) => {
+      if (el.tagName === 'SCRIPT') {
+        injected.push(el as HTMLScriptElement)
+        queueMicrotask(() => (el as HTMLScriptElement).onload?.(new Event('load')))
+        return el
+      }
+      return Node.prototype.appendChild.call(document.head, el)
     }) as typeof document.head.appendChild)
   })
 
@@ -75,5 +83,50 @@ describe('drupalLibraryLoader', () => {
     )
     expect((window as unknown as { drupalSettings: Record<string, unknown> }).drupalSettings)
       .toEqual({ my_module: { some_key: 'value' } })
+  })
+
+  it('absolutizes root-relative AJAX urls against the backend and re-keys ajaxTrustedUrl', async () => {
+    const settings = {
+      ajax: {
+        'edit-upload-button': {
+          url: '/form/x?ajax_form=1',
+          callback: 'foo',
+          progress: { type: 'bar', url: '/file/progress/123' },
+        },
+      },
+      ajaxTrustedUrl: { '/form/x?ajax_form=1': true },
+    }
+    await loadDrupalLibrary(
+      { js: [{ url: '/a.js' }], drupalSettings: JSON.stringify(settings) },
+      'http://backend',
+    )
+    const seeded = (window as unknown as { drupalSettings: typeof settings }).drupalSettings
+    expect(seeded.ajax['edit-upload-button'].url).toBe('http://backend/form/x?ajax_form=1')
+    expect(seeded.ajax['edit-upload-button'].progress.url).toBe('http://backend/file/progress/123')
+    // The absolute url must be trusted — ajax.js throws on an untrusted
+    // cross-origin callback url and relies on trust to accept multipart uploads.
+    expect(seeded.ajaxTrustedUrl).toEqual({ 'http://backend/form/x?ajax_form=1': true })
+  })
+
+  it('leaves already-absolute AJAX urls untouched (idempotent)', async () => {
+    const settings = {
+      ajax: { btn: { url: 'http://backend/form/x' } },
+      ajaxTrustedUrl: { 'http://backend/form/x': true },
+    }
+    await loadDrupalLibrary(
+      { js: [{ url: '/a.js' }], drupalSettings: JSON.stringify(settings) },
+      'http://backend',
+    )
+    const seeded = (window as unknown as { drupalSettings: typeof settings }).drupalSettings
+    expect(seeded.ajax.btn.url).toBe('http://backend/form/x')
+    expect(seeded.ajaxTrustedUrl).toEqual({ 'http://backend/form/x': true })
+  })
+
+  it('injects the js-hide rule once, even across calls', async () => {
+    await loadDrupalLibrary({ js: [{ url: '/a.js' }] }, 'http://backend')
+    await loadDrupalLibrary({ js: [{ url: '/b.js' }] }, 'http://backend')
+    const styles = document.head.querySelectorAll('style[data-drupal-base-styles]')
+    expect(styles).toHaveLength(1)
+    expect(styles[0]!.textContent).toContain('.js .js-hide')
   })
 })

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -125,6 +125,24 @@ describe('drupalLibraryLoader', () => {
     expect(seeded.ajaxPageState).toEqual({ theme: 'olivero', theme_token: 'tok', libraries: 'abc' })
   })
 
+  it('reports loaded library names as ajaxPageState.libraries so the backend skips their assets', async () => {
+    // The backend diffs its AJAX-response assets against ajaxPageState.libraries.
+    // Reporting what the drupal-library components loaded (a plain comma list)
+    // stops it re-sending add_css/add_js for libraries already on the page, and a
+    // non-empty list avoids the empty-'' entry that trips core's asset resolver.
+    await loadDrupalLibrary(
+      { name: 'core/drupal.ajax', js: [{ url: '/ajax.js' }], drupalSettings: '{"ajax":{"edit-x":{"url":"/form/x?ajax_form=1"}}}' },
+      'http://backend',
+    )
+    // A later element carries only its name (drupalSettings is on the first only).
+    await loadDrupalLibrary(
+      { name: 'webform/webform.element.managed_file', js: [{ url: '/managed-file.js' }] },
+      'http://backend',
+    )
+    const seeded = (window as unknown as { drupalSettings: { ajaxPageState: { libraries: string } } }).drupalSettings
+    expect(seeded.ajaxPageState.libraries).toBe('core/drupal.ajax,webform/webform.element.managed_file')
+  })
+
   it('keeps AJAX urls root-relative so they route through the same-origin form proxy', async () => {
     // The AJAX callback url must stay root-relative: it then resolves against the
     // frontend origin, where the drupalFormHandler middleware proxies the request

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -81,7 +81,11 @@ describe('drupalLibraryLoader', () => {
       .toEqual({ my_module: { some_key: 'value' } })
   })
 
-  it('absolutizes root-relative AJAX urls against the backend and re-keys ajaxTrustedUrl', async () => {
+  it('keeps AJAX urls root-relative so they route through the same-origin form proxy', async () => {
+    // The AJAX callback url must stay root-relative: it then resolves against the
+    // frontend origin, where the drupalFormHandler middleware proxies the request
+    // (and its ?ajax_form=1 response) to the backend. Absolutizing it here would
+    // instead send Drupal.ajax cross-origin and bypass the proxy.
     const settings = {
       ajax: {
         'edit-upload-button': {
@@ -97,24 +101,8 @@ describe('drupalLibraryLoader', () => {
       'http://backend',
     )
     const seeded = (window as unknown as { drupalSettings: typeof settings }).drupalSettings
-    expect(seeded.ajax['edit-upload-button'].url).toBe('http://backend/form/x?ajax_form=1')
-    expect(seeded.ajax['edit-upload-button'].progress.url).toBe('http://backend/file/progress/123')
-    // The absolute url must be trusted — ajax.js throws on an untrusted
-    // cross-origin callback url and relies on trust to accept multipart uploads.
-    expect(seeded.ajaxTrustedUrl).toEqual({ 'http://backend/form/x?ajax_form=1': true })
-  })
-
-  it('leaves already-absolute AJAX urls untouched (idempotent)', async () => {
-    const settings = {
-      ajax: { btn: { url: 'http://backend/form/x' } },
-      ajaxTrustedUrl: { 'http://backend/form/x': true },
-    }
-    await loadDrupalLibrary(
-      { js: [{ url: '/a.js' }], drupalSettings: JSON.stringify(settings) },
-      'http://backend',
-    )
-    const seeded = (window as unknown as { drupalSettings: typeof settings }).drupalSettings
-    expect(seeded.ajax.btn.url).toBe('http://backend/form/x')
-    expect(seeded.ajaxTrustedUrl).toEqual({ 'http://backend/form/x': true })
+    expect(seeded.ajax['edit-upload-button'].url).toBe('/form/x?ajax_form=1')
+    expect(seeded.ajax['edit-upload-button'].progress.url).toBe('/file/progress/123')
+    expect(seeded.ajaxTrustedUrl).toEqual({ '/form/x?ajax_form=1': true })
   })
 })

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -26,13 +26,9 @@ describe('drupalLibraryLoader', () => {
     if (!globalThis.CSS) {
       globalThis.CSS = { escape: (s: string) => s } as unknown as typeof CSS
     }
-    // The DOM persists across tests; drop any base-styles <style> a prior test
-    // injected so the once-guard starts clean.
-    document.head.querySelectorAll('style[data-drupal-base-styles]').forEach(el => el.remove())
 
     // Mock script insertion: record scripts and fire onload on the next
-    // microtask. Non-scripts (the injected base-styles <style>) are inserted for
-    // real so the loader's once-guard querySelector can find them.
+    // microtask.
     vi.spyOn(document.head, 'appendChild').mockImplementation(((el: HTMLElement) => {
       if (el.tagName === 'SCRIPT') {
         injected.push(el as HTMLScriptElement)
@@ -120,13 +116,5 @@ describe('drupalLibraryLoader', () => {
     const seeded = (window as unknown as { drupalSettings: typeof settings }).drupalSettings
     expect(seeded.ajax.btn.url).toBe('http://backend/form/x')
     expect(seeded.ajaxTrustedUrl).toEqual({ 'http://backend/form/x': true })
-  })
-
-  it('injects the js-hide rule once, even across calls', async () => {
-    await loadDrupalLibrary({ js: [{ url: '/a.js' }] }, 'http://backend')
-    await loadDrupalLibrary({ js: [{ url: '/b.js' }] }, 'http://backend')
-    const styles = document.head.querySelectorAll('style[data-drupal-base-styles]')
-    expect(styles).toHaveLength(1)
-    expect(styles[0]!.textContent).toContain('.js .js-hide')
   })
 })

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -78,7 +78,44 @@ describe('drupalLibraryLoader', () => {
       'http://backend',
     )
     expect((window as unknown as { drupalSettings: Record<string, unknown> }).drupalSettings)
-      .toEqual({ my_module: { some_key: 'value' } })
+      .toEqual({ my_module: { some_key: 'value' }, ajaxPageState: { theme: '', theme_token: null, libraries: '' } })
+  })
+
+  it('writes a drupal-settings-json <script> so core drupalSettingsLoader.js repopulates instead of wiping settings', async () => {
+    await loadDrupalLibrary(
+      { js: [{ url: '/core/misc/drupalSettingsLoader.js' }], drupalSettings: '{"ajax":{"edit-x":{"url":"/form/x?ajax_form=1"}}}' },
+      'http://backend',
+    )
+    // core/misc/drupalSettingsLoader.js resets window.drupalSettings to {} and
+    // only repopulates it from this element; without it the AJAX settings (and
+    // thus the managed_file upload's Drupal.ajax instance) are lost.
+    const el = injected.find(s => s.type === 'application/json' && s.dataset.drupalSelector === 'drupal-settings-json')
+    expect(el).toBeDefined()
+    expect(JSON.parse(el!.textContent!)).toEqual({
+      ajax: { 'edit-x': { url: '/form/x?ajax_form=1' } },
+      ajaxPageState: { theme: '', theme_token: null, libraries: '' },
+    })
+  })
+
+  it('defaults drupalSettings.ajaxPageState so Ajax.beforeSerialize does not throw', async () => {
+    // core/misc/ajax.js Drupal.Ajax.beforeSerialize reads ajaxPageState.theme /
+    // .theme_token / .libraries; a CE-rendered form omits ajaxPageState, so
+    // without a default beforeSerialize throws and no request is ever sent.
+    await loadDrupalLibrary(
+      { js: [{ url: '/a.js' }], drupalSettings: '{"ajax":{"edit-x":{"url":"/form/x?ajax_form=1"}}}' },
+      'http://backend',
+    )
+    const seeded = (window as unknown as { drupalSettings: { ajaxPageState?: Record<string, unknown> } }).drupalSettings
+    expect(seeded.ajaxPageState).toEqual({ theme: '', theme_token: null, libraries: '' })
+  })
+
+  it('keeps a backend-provided ajaxPageState instead of overwriting it', async () => {
+    await loadDrupalLibrary(
+      { js: [{ url: '/a.js' }], drupalSettings: '{"ajaxPageState":{"theme":"olivero","theme_token":"tok","libraries":"abc"}}' },
+      'http://backend',
+    )
+    const seeded = (window as unknown as { drupalSettings: { ajaxPageState?: Record<string, unknown> } }).drupalSettings
+    expect(seeded.ajaxPageState).toEqual({ theme: 'olivero', theme_token: 'tok', libraries: 'abc' })
   })
 
   it('keeps AJAX urls root-relative so they route through the same-origin form proxy', async () => {

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -104,6 +104,15 @@ describe('drupalLibraryLoader', () => {
       })
   })
 
+  it('skips site-configured scripts (skipLibraryScripts substring match)', async () => {
+    await loadDrupalLibrary(
+      { js: [{ url: '/core/misc/tabledrag.js?v=1' }, { url: '/core/misc/drupal.js?v=1' }] },
+      'http://backend',
+      ['tabledrag.js'],
+    )
+    expect(injected.map(s => s.src)).toEqual(['http://backend/core/misc/drupal.js?v=1'])
+  })
+
   it('defaults drupalSettings.ajaxPageState so Ajax.beforeSerialize does not throw', async () => {
     // core/misc/ajax.js Drupal.Ajax.beforeSerialize reads ajaxPageState.theme /
     // .theme_token / .libraries; a CE-rendered form omits ajaxPageState, so


### PR DESCRIPTION
Fixes webform `managed_file` (and any Drupal AJAX form) uploads on the decoupled frontend.

## Approach: proxy AJAX form requests (variant C)

Core builds a form element's `#ajax` callback URL from `Url::fromRoute('<current>')` → a **root-relative** path (`/form/x?ajax_form=1`). On a decoupled page that URL resolves against the frontend origin, so `Drupal.ajax` POSTs the upload here — and it already flows into the existing `drupalFormHandler` proxy middleware. The only gap was the response handling.

### `drupalFormHandler` middleware
- Detect Drupal AJAX form requests (`?ajax_form=1`).
- Proxy them to the backend (as before) but **return Drupal's raw AJAX command response verbatim** — short-circuiting the SSR page render, which is only correct for a full (non-AJAX) submit.
- Pass the backend response headers through, notably `X-Drupal-Ajax-Token` (ajax.js rejects an AJAX response without it) and `Set-Cookie`.

Keeping the request same-origin means no cross-origin credentialed CORS is involved for the upload round-trip.

### `drupalLibraryLoader`
- **Removed** `absolutizeAjaxSettings` (the earlier variant-A approach). The AJAX callback URL must stay root-relative so it routes through the same-origin proxy above instead of going cross-origin to the backend.

### js-hide (AC #5)
- `.js .js-hide { display: none }` ships from the `drupal-library--default` component's `<style>` (core's `system/base` CSS is never loaded on the decoupled frontend), so the managed_file "Upload" button is hidden while JS is active.

## Verification
- **Verified (this session):** full vitest suite 149 passed / 0 failed; eslint clean. New e2e coverage in `test/e2e/drupalFormHandler.test.ts` asserts an `?ajax_form=1` multipart POST is proxied and returns the raw AJAX command JSON + `X-Drupal-Ajax-Token`, and that a non-AJAX POST still renders a page. Loader unit test asserts AJAX URLs stay root-relative.
- **NOT verified (needs a live env):** the end-to-end browser upload against a real backend (ACs 1–4, 6) — file shown with „Entfernen", submission storing it, size/extension validation. That needs this package released, kickstart bumped, and a manual/e2e check on beta. LDP gets a Playwright upload spec (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
