### PR TITLE
fix: render custom element arrays as a Fragment to avoid remounting on re-render

### DIFF
--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -573,12 +573,11 @@ export const useDrupalCe = () => {
   ): VNode | null => {
     const vnodes = renderCustomElementsToVNodes(customElements)
 
-    // Wrap a VNode[] in a Fragment so <component :is> receives a single vnode
-    // of a stable type. Re-invoking this helper on a re-render (the documented
-    // template usage) then yields a same-type Fragment that Vue patches in
-    // place. Returning a fresh component identity per call instead makes
-    // <component :is> unmount and remount the whole custom-element subtree on
-    // any unrelated re-render, discarding component state, focus and scroll.
+    // Wrap a VNode[] in a Fragment so <component :is> receives a single vnode.
+    // The documented template usage re-invokes this helper on every re-render
+    // of the consumer, so the wrapper must keep the same vnode type across
+    // calls: same-type Fragments are patched in place, preserving component
+    // state, focus and scroll in the custom-element subtree.
     if (Array.isArray(vnodes)) {
       return h(Fragment, vnodes)
     }

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -1,12 +1,12 @@
 import { defu } from 'defu'
 import { appendResponseHeader } from 'h3'
 import type { $Fetch, NitroFetchRequest } from 'nitropack'
-import { type Ref, type ComputedRef, type Component, type VNode, Fragment } from 'vue'
+import { type Ref, type ComputedRef, type VNode, Fragment } from 'vue'
 import { getDrupalBaseUrl, getMenuBaseUrl, headersToRecord } from './server'
 import type { DrupalResolvedLibrary } from './drupalLibraryLoader'
 import type { UseFetchOptions, AsyncData } from '#app'
 import { callWithNuxt } from '#app'
-import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, watch, useRequestEvent, computed, useHead, defineComponent, toRef, useRoute, useRouter, useSlots } from '#imports'
+import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, watch, useRequestEvent, computed, useHead, toRef, useRoute, useRouter, useSlots } from '#imports'
 import type { DrupalCePage, DrupalCeApiResponse } from '../../types'
 
 // Cache the dynamic import of the library loader in a single module-level
@@ -556,13 +556,12 @@ export const useDrupalCe = () => {
    * Renders Vue components from JSON-serialized custom element data.
    *
    * Wrapper around renderCustomElementsToVNodes that makes the result compatible with
-   * <component :is> by wrapping VNode[] in a Component.
+   * <component :is> by wrapping VNode[] in a single Fragment VNode.
    *
    * @param customElements {CustomElementContent} - Custom element data to render.
    *          See {@link https://github.com/drunomics/nuxtjs-drupal-ce/blob/2.x/src/runtime/types.d.ts} type definition for detailed structure documentation.
-   * @returns VNode | Component | null
-   *          - VNode: For single elements and strings
-   *          - Component: For arrays (wraps VNode[] in defineComponent for <component :is> compatibility)
+   * @returns VNode | null
+   *          - VNode: For single elements, strings, and arrays (arrays as a Fragment VNode)
    *          - null: For empty/null input
    *
    * Usage:
@@ -571,16 +570,17 @@ export const useDrupalCe = () => {
    */
   const renderCustomElements = (
     customElements: CustomElementContent,
-  ): VNode | Component | null => {
+  ): VNode | null => {
     const vnodes = renderCustomElementsToVNodes(customElements)
 
-    // If we got an array of VNodes, wrap in a Component for <component :is> compatibility
+    // Wrap a VNode[] in a Fragment so <component :is> receives a single vnode
+    // of a stable type. Re-invoking this helper on a re-render (the documented
+    // template usage) then yields a same-type Fragment that Vue patches in
+    // place. Returning a fresh component identity per call instead makes
+    // <component :is> unmount and remount the whole custom-element subtree on
+    // any unrelated re-render, discarding component state, focus and scroll.
     if (Array.isArray(vnodes)) {
-      return defineComponent({
-        setup() {
-          return () => vnodes
-        }
-      })
+      return h(Fragment, vnodes)
     }
 
     // Single VNode or null - return as-is

--- a/test/nuxt/renderCustomElements.test.ts
+++ b/test/nuxt/renderCustomElements.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment nuxt
 import { describe, it, expect, beforeAll } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { defineComponent } from 'vue'
+import { defineComponent, h, ref, nextTick } from 'vue'
 import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
 import {useNuxtApp} from "#imports";
 
@@ -26,11 +26,23 @@ describe('renderCustomElements', () => {
     },
     template: '<section>Another Component: {{ bar }}</section>'
   })
+
+  // Counts how many times it is mounted, so a test can tell an in-place patch
+  // from a full remount of the custom-element subtree.
+  let mountCount = 0
+  const MountCounter = defineComponent({
+    name: 'MountCounter',
+    setup() {
+      mountCount++
+      return () => h('span', 'counted')
+    }
+  })
   beforeAll(() => {
     ({ renderCustomElements } = useDrupalCe())
     const app = useNuxtApp()
     app.vueApp.component('TestComponent', TestComponent)
     app.vueApp.component('AnotherComponent', AnotherComponent)
+    app.vueApp.component('MountCounter', MountCounter)
   })
 
   describe('basic input handling', () => {
@@ -149,6 +161,31 @@ describe('renderCustomElements', () => {
       expect(wrapper.text()).toContain('Another Component: two')
       expect(wrapper.html()).toEqual("<section>Test Component: one</section>\n" +
         "<section>Another Component: two</section>")
+    })
+
+    it('does not remount the subtree when the consumer re-renders', async () => {
+      // The documented usage re-invokes renderCustomElements on every render of
+      // the consuming component. The array result must render as a stable-type
+      // vnode so an unrelated re-render patches it in place rather than
+      // unmounting and remounting the whole subtree.
+      mountCount = 0
+      const tick = ref(0)
+      const wrapper = await mountSuspended(defineComponent({
+        setup() {
+          return { tick, render: () => renderCustomElements([
+            { element: 'mount-counter' },
+            { element: 'test-component', foo: 'x' }
+          ]) }
+        },
+        template: '<div><span class="tick">{{ tick }}</span><component :is="render()" /></div>'
+      }))
+      expect(mountCount).toBe(1)
+
+      tick.value++
+      await nextTick()
+
+      expect(mountCount).toBe(1)
+      expect(wrapper.text()).toContain('Test Component: x')
     })
   })
 


### PR DESCRIPTION
Closes #530.

## Problem

`renderCustomElements()` is documented for `<component :is="renderCustomElements(page.content)" />`, which Vue re-evaluates on every render of the consuming component. For an **array** payload it returned a freshly created anonymous component on each call, so `<component :is>` saw a new component type every render and **unmounted then remounted the entire custom-element subtree** on any unrelated re-render — discarding component state, focus and scroll position. Single-element payloads (returned as a plain `VNode`) were unaffected, which makes the bug easy to miss.

## Fix

Wrap the `VNode[]` in a **Fragment** instead of a new `defineComponent`:

```ts
if (Array.isArray(vnodes)) {
  return h(Fragment, vnodes)
}
```

A Fragment has a stable type, so a re-render patches the children in place rather than remounting, while still reflecting content changes. `<component :is>` accepts a `VNode`, so the documented template usage is unchanged and the rendered markup is identical (a Fragment emits its children with no wrapper element). The return type narrows from `VNode | Component | null` to `VNode | null`.

## Test

Adds a regression test to `test/nuxt/renderCustomElements.test.ts` that renders an array payload the documented way, bumps an unrelated ref to force a parent re-render, and asserts a mount-counting child is **not** remounted. It fails on the old code (mount count 2) and passes with this fix (mount count 1). The existing array-rendering assertions (markup output, empty arrays) are unchanged.

## Notes

Drafted with assistance from Claude Code.