### PR TITLE
feat: MCD-1400 Add an option to pass custom element components only declared props.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ The components should be placed in `~/components/global`, refer to the `/playgro
 For example, for the custom element `node-article-teaser` a global component `node-article-teaser.vue` would be
 picked up for rendering.
 
+### Declared props only
+
+A custom element is a data payload, not a set of HTML attributes: a component
+receives only the props it declares. Everything else is dropped instead of
+falling through onto the rendered element as a non-standard HTML attribute — so
+adding a field on the Drupal side never changes the markup of a component that
+does not ask for it. In dev mode the dropped keys are logged.
+
+Attributes that are valid on any element pass through regardless: `class`,
+`style`, `id`, `role`, `lang`, `dir`, `hidden`, `tabindex`, `data-*`,
+`aria-*` and event listeners.
+
 ### JSON Format Options
 
 The module supports two JSON formats for custom elements:

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ is added automatically to requests. Defaults to `false`.
 
 - `enableComponentPreview`: Enable component preview for Drupal Canvas integration. Automatically configures CORS based on `drupalBaseUrl`. Set to `false` to disable. Defaults to `true`.
 
+- `customElementDeclaredPropsOnly`: Pass a custom element component only the props it declares, see [Declared props only](#declared-props-only). Defaults to `false`.
+
 - `skipLibraryScripts`: List of URL substrings for Drupal JS files the library loader must not load (in addition to `core/misc/drupalSettingsLoader.js`, which is always skipped). Defaults to `[]`.
 
 ## Overriding options with environment variables
@@ -137,15 +139,27 @@ picked up for rendering.
 
 ### Declared props only
 
-A custom element is a data payload, not a set of HTML attributes: a component
-receives only the props it declares. Everything else is dropped instead of
-falling through onto the rendered element as a non-standard HTML attribute — so
-adding a field on the Drupal side never changes the markup of a component that
-does not ask for it. In dev mode the dropped keys are logged.
+By default a component receives the whole custom element payload, and Vue lets
+every key it does not declare as a prop fall through onto the rendered element
+as an HTML attribute. A field added on the Drupal side then shows up in the
+markup of components that never asked for it.
 
-Attributes that are valid on any element pass through regardless: `class`,
-`style`, `id`, `role`, `lang`, `dir`, `hidden`, `tabindex`, `data-*`,
-`aria-*` and event listeners.
+Opt out of that fallthrough with:
+
+```js
+drupalCe: {
+  customElementDeclaredPropsOnly: true
+}
+```
+
+A component then receives only the props it declares; the remaining payload
+keys are dropped and, in dev mode, logged. Attributes that are valid on any
+element still pass through, so Drupal's own `attributes` keep working: `class`,
+`style`, `id`, `role`, `lang`, `dir`, `hidden`, `tabindex`, `data-*`, `aria-*`
+and event listeners.
+
+A component that reads undeclared payload keys out of `$attrs` and relays them
+to a child must declare them as props before turning this on.
 
 ### JSON Format Options
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -61,6 +61,8 @@ export interface ModuleOptions {
   serverLogLevel?: boolean | 'info' | 'error'
   disableFormHandler?: boolean | string[]
   enableComponentPreview?: boolean
+  /** Pass custom element components only the props they declare. */
+  customElementDeclaredPropsOnly?: boolean
   /** Extra Drupal JS URLs (substring match) the library loader must not load. */
   skipLibraryScripts?: string[]
 }
@@ -90,6 +92,7 @@ export default defineNuxtModule<ModuleOptions>({
     serverLogLevel: 'info',
     disableFormHandler: false,
     enableComponentPreview: true,
+    customElementDeclaredPropsOnly: false,
     skipLibraryScripts: [],
   },
   async setup(options, nuxt) {

--- a/src/runtime/composables/useDrupalCe/customElementProps.ts
+++ b/src/runtime/composables/useDrupalCe/customElementProps.ts
@@ -1,0 +1,71 @@
+import { camelize, defineAsyncComponent, defineComponent, h } from 'vue'
+import type { Component, ConcreteComponent } from 'vue'
+
+// A custom element carries a data payload, not HTML attributes. Keys a
+// component does not declare as props would fall through to its root element
+// and render as non-standard attributes, so they are dropped instead. Global
+// HTML attributes, `data-`/`aria-` and event listeners stay: they are valid on
+// any element and are how Drupal passes real attributes through.
+const DOM_ATTRIBUTE = /^(class|style|id|role|lang|dir|hidden|tabindex|data-.+|aria-.+|on[A-Z].*)$/
+
+// Keyed by the resolved component so a re-render reuses the same wrapper.
+// A fresh wrapper on every render would be a new vnode type, remounting the
+// whole custom-element subtree.
+const wrappers = new WeakMap<object, Component>()
+
+/** Prop names the component declares, camelized like Vue's own prop lookup. */
+const declaredProps = (component: ConcreteComponent): Set<string> => {
+  const props = (component as { props?: string[] | Record<string, unknown> }).props
+  const names = Array.isArray(props) ? props : Object.keys(props ?? {})
+  return new Set(names.map(camelize))
+}
+
+/** A component rendering `component` with the undeclared keys removed. */
+const propFilter = (component: ConcreteComponent): Component => {
+  const declared = declaredProps(component)
+  const name = (component as { name?: string }).name
+
+  return defineComponent({
+    name: name ? `CustomElement:${name}` : 'CustomElement',
+    // The payload arrives as `$attrs`, so nothing may fall through untouched.
+    inheritAttrs: false,
+    setup(_props, { attrs, slots }) {
+      return () => {
+        const props: Record<string, unknown> = {}
+        const dropped: string[] = []
+        for (const key in attrs) {
+          if (declared.has(camelize(key)) || DOM_ATTRIBUTE.test(key)) {
+            props[key] = attrs[key]
+          }
+          else {
+            dropped.push(key)
+          }
+        }
+        if (import.meta.dev && dropped.length) {
+          console.warn(`[nuxtjs-drupal-ce] <${name ?? 'custom element'}> does not declare ${dropped.join(', ')} as props — dropped instead of rendering them as attributes.`)
+        }
+        return h(component, props, slots)
+      }
+    },
+  })
+}
+
+/**
+ * Wraps a resolved custom element so it only receives the props it declares.
+ *
+ * Nuxt registers global components asynchronously, so the declared props are
+ * known only once the component has loaded — hence the async wrapper, which
+ * suspends exactly like the component it replaces.
+ */
+export const withDeclaredProps = (component: ConcreteComponent): Component => {
+  const cached = wrappers.get(component)
+  if (cached) {
+    return cached
+  }
+  const loader = (component as { __asyncLoader?: () => Promise<ConcreteComponent> }).__asyncLoader
+  const wrapper = loader
+    ? defineAsyncComponent(() => loader().then(propFilter))
+    : propFilter(component)
+  wrappers.set(component, wrapper)
+  return wrapper
+}

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -3,6 +3,7 @@ import { appendResponseHeader } from 'h3'
 import type { $Fetch, NitroFetchRequest } from 'nitropack'
 import { type Ref, type ComputedRef, type VNode, Fragment } from 'vue'
 import { getDrupalBaseUrl, getMenuBaseUrl, headersToRecord } from './server'
+import { withDeclaredProps } from './customElementProps'
 import type { DrupalResolvedLibrary } from './drupalLibraryLoader'
 import type { UseFetchOptions, AsyncData } from '#app'
 import { callWithNuxt } from '#app'
@@ -491,6 +492,18 @@ export const useDrupalCe = () => {
   }
 
   /**
+   * Resolve a custom element into the component that renders it.
+   *
+   * The component only receives the props it declares: a custom element is a
+   * data payload, so anything undeclared would fall through onto the rendered
+   * element as a non-standard HTML attribute.
+   */
+  const resolveCustomElementComponent = (element: string) => {
+    const resolved = resolveCustomElement(element)
+    return resolved ? withDeclaredProps(resolved) : null
+  }
+
+  /**
    * Converts custom element data to VNodes for use in slots and render functions.
    *
    * This is the main rendering function that contains all the logic for converting
@@ -550,14 +563,14 @@ export const useDrupalCe = () => {
         }
         // Use legacy format handling
         const { element, ...props } = customElements
-        const resolvedElement = resolveCustomElement(element)
+        const resolvedElement = resolveCustomElementComponent(element)
         return resolvedElement ? h(resolvedElement, props) : null
       }
 
       // Use explicit format: {element, props?, slots?}
       const explicitElement = customElements as CustomElementExplicitContent
       const { element, props = {}, slots = {} } = explicitElement
-      const resolvedElement = resolveCustomElement(element)
+      const resolvedElement = resolveCustomElementComponent(element)
 
       if (!resolvedElement) {
         return null
@@ -574,7 +587,7 @@ export const useDrupalCe = () => {
     else {
       // Config is 'legacy' - use legacy format handling
       const { element, ...props } = customElements
-      const resolvedElement = resolveCustomElement(element)
+      const resolvedElement = resolveCustomElementComponent(element)
       return resolvedElement ? h(resolvedElement, props) : null
     }
   }

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -494,13 +494,16 @@ export const useDrupalCe = () => {
   /**
    * Resolve a custom element into the component that renders it.
    *
-   * The component only receives the props it declares: a custom element is a
-   * data payload, so anything undeclared would fall through onto the rendered
-   * element as a non-standard HTML attribute.
+   * With `customElementDeclaredPropsOnly` the component receives only the props
+   * it declares, so undeclared payload keys cannot fall through onto the
+   * rendered element as non-standard HTML attributes.
    */
   const resolveCustomElementComponent = (element: string) => {
     const resolved = resolveCustomElement(element)
-    return resolved ? withDeclaredProps(resolved) : null
+    if (!resolved) {
+      return null
+    }
+    return config.customElementDeclaredPropsOnly ? withDeclaredProps(resolved) : resolved
   }
 
   /**

--- a/test/nuxt/components/preview.test.ts
+++ b/test/nuxt/components/preview.test.ts
@@ -7,7 +7,7 @@ describe('Preview routes', () => {
   registerEndpoint('http://127.0.0.1:3021/ce-api/node/preview/node', () => ({
     content: {
       element: 'node-article',
-      body: '<p>Some <b>example</b> body.</p>'
+      slots: { body: '<p>Some <b>example</b> body.</p>' }
     },
     local_tasks: {},
     messages: [],
@@ -17,7 +17,7 @@ describe('Preview routes', () => {
   registerEndpoint('http://127.0.0.1:3021/ce-api/node/5/layout-preview', () => ({
     content: {
       element: 'node-article',
-      body: '<p>Some <b>example</b> body.</p>'
+      slots: { body: '<p>Some <b>example</b> body.</p>' }
     },
     local_tasks: {},
     messages: [],

--- a/test/nuxt/customElementProps.test.ts
+++ b/test/nuxt/customElementProps.test.ts
@@ -1,15 +1,16 @@
 // @vitest-environment nuxt
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { defineAsyncComponent, defineComponent, h, ref, nextTick } from 'vue'
 import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
-import { useNuxtApp } from '#imports'
+import { useNuxtApp, useRuntimeConfig } from '#imports'
 
-// A custom element is a data payload. Every key the rendering component does
-// not declare as a prop would otherwise fall through onto its root element as
-// a non-standard HTML attribute.
+// A custom element is a data payload. With `customElementDeclaredPropsOnly`
+// every key the rendering component does not declare as a prop is dropped
+// instead of falling through onto its root element as an HTML attribute.
 describe('custom element props', () => {
   let renderCustomElements: ReturnType<typeof useDrupalCe>['renderCustomElements']
+  let config: Record<string, unknown>
 
   const Teaser = defineComponent({
     name: 'Teaser',
@@ -34,6 +35,7 @@ describe('custom element props', () => {
 
   beforeAll(() => {
     ({ renderCustomElements } = useDrupalCe())
+    config = useRuntimeConfig().public.drupalCe
     const app = useNuxtApp()
     app.vueApp.component('Teaser', Teaser)
     app.vueApp.component('AsyncTeaser', AsyncTeaser)
@@ -47,63 +49,84 @@ describe('custom element props', () => {
     template: '<component :is="component" />',
   }))
 
-  it('drops keys the component does not declare', async () => {
-    const wrapper = await render({
-      element: 'teaser',
-      title: 'A title',
-      heroType: 'wide',
-      authorHref: '/author/1',
+  describe('by default', () => {
+    it('leaves undeclared keys to Vue attribute fallthrough', async () => {
+      const wrapper = await render({
+        element: 'teaser',
+        title: 'A title',
+        heroType: 'wide',
+      })
+      expect(wrapper.html()).toContain('herotype="wide"')
     })
-    expect(wrapper.html()).toBe('<article>A title</article>')
   })
 
-  it('drops keys an asynchronously registered component does not declare', async () => {
-    const wrapper = await render({
-      element: 'async-teaser',
-      title: 'A title',
-      heroType: 'wide',
+  describe('with customElementDeclaredPropsOnly', () => {
+    beforeAll(() => {
+      config.customElementDeclaredPropsOnly = true
     })
-    expect(wrapper.html()).toBe('<article>A title</article>')
-  })
 
-  it('keeps attributes that are valid on any element', async () => {
-    const wrapper = await render({
-      'element': 'teaser',
-      'title': 'A title',
-      'class': 'is-featured',
-      'id': 'teaser-1',
-      'data-id': 'teaser',
-      'aria-hidden': 'true',
-      'heroType': 'wide',
+    afterAll(() => {
+      config.customElementDeclaredPropsOnly = false
     })
-    const article = wrapper.find('article').element
-    expect(Array.from(article.attributes).map(attribute => attribute.name).sort())
-      .toEqual(['aria-hidden', 'class', 'data-id', 'id'])
-  })
 
-  it('renders slots of the explicit format', async () => {
-    const wrapper = await render({
-      element: 'teaser',
-      props: { title: 'A title', heroType: 'wide' },
-      slots: { default: '<p>Slotted</p>' },
+    it('drops keys the component does not declare', async () => {
+      const wrapper = await render({
+        element: 'teaser',
+        title: 'A title',
+        heroType: 'wide',
+        authorHref: '/author/1',
+      })
+      expect(wrapper.html()).toBe('<article>A title</article>')
     })
-    expect(wrapper.html()).toContain('<p>Slotted</p>')
-    expect(wrapper.html()).not.toContain('herotype')
-  })
 
-  it('patches in place instead of remounting on re-render', async () => {
-    const title = ref('First')
-    const wrapper = await mountSuspended(defineComponent({
-      setup() {
-        return () => h('div', [renderCustomElements({ element: 'mount-counter', title: title.value, heroType: 'wide' })])
-      },
-    }))
-    expect(mountCount).toBe(1)
-    expect(wrapper.html()).toContain('First')
+    it('drops keys an asynchronously registered component does not declare', async () => {
+      const wrapper = await render({
+        element: 'async-teaser',
+        title: 'A title',
+        heroType: 'wide',
+      })
+      expect(wrapper.html()).toBe('<article>A title</article>')
+    })
 
-    title.value = 'Second'
-    await nextTick()
-    expect(wrapper.html()).toContain('Second')
-    expect(mountCount).toBe(1)
+    it('keeps attributes that are valid on any element', async () => {
+      const wrapper = await render({
+        'element': 'teaser',
+        'title': 'A title',
+        'class': 'is-featured',
+        'id': 'teaser-1',
+        'data-id': 'teaser',
+        'aria-hidden': 'true',
+        'heroType': 'wide',
+      })
+      const article = wrapper.find('article').element
+      expect(Array.from(article.attributes).map(attribute => attribute.name).sort())
+        .toEqual(['aria-hidden', 'class', 'data-id', 'id'])
+    })
+
+    it('renders slots of the explicit format', async () => {
+      const wrapper = await render({
+        element: 'teaser',
+        props: { title: 'A title', heroType: 'wide' },
+        slots: { default: '<p>Slotted</p>' },
+      })
+      expect(wrapper.html()).toContain('<p>Slotted</p>')
+      expect(wrapper.html()).not.toContain('herotype')
+    })
+
+    it('patches in place instead of remounting on re-render', async () => {
+      const title = ref('First')
+      const wrapper = await mountSuspended(defineComponent({
+        setup() {
+          return () => h('div', [renderCustomElements({ element: 'mount-counter', title: title.value, heroType: 'wide' })])
+        },
+      }))
+      expect(mountCount).toBe(1)
+      expect(wrapper.html()).toContain('First')
+
+      title.value = 'Second'
+      await nextTick()
+      expect(wrapper.html()).toContain('Second')
+      expect(mountCount).toBe(1)
+    })
   })
 })

--- a/test/nuxt/customElementProps.test.ts
+++ b/test/nuxt/customElementProps.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment nuxt
+import { describe, it, expect, beforeAll } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineAsyncComponent, defineComponent, h, ref, nextTick } from 'vue'
+import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
+import { useNuxtApp } from '#imports'
+
+// A custom element is a data payload. Every key the rendering component does
+// not declare as a prop would otherwise fall through onto its root element as
+// a non-standard HTML attribute.
+describe('custom element props', () => {
+  let renderCustomElements: ReturnType<typeof useDrupalCe>['renderCustomElements']
+
+  const Teaser = defineComponent({
+    name: 'Teaser',
+    props: { title: String },
+    template: '<article>{{ title }}<slot /></article>',
+  })
+
+  // Nuxt registers global components asynchronously, so their declared props
+  // are unknown until the component has loaded.
+  const AsyncTeaser = defineAsyncComponent(() => Promise.resolve(Teaser))
+
+  // Counts mounts, so a test can tell an in-place patch from a remount.
+  let mountCount = 0
+  const MountCounter = defineComponent({
+    name: 'MountCounter',
+    props: { title: String },
+    setup(props) {
+      mountCount++
+      return () => h('span', props.title)
+    },
+  })
+
+  beforeAll(() => {
+    ({ renderCustomElements } = useDrupalCe())
+    const app = useNuxtApp()
+    app.vueApp.component('Teaser', Teaser)
+    app.vueApp.component('AsyncTeaser', AsyncTeaser)
+    app.vueApp.component('MountCounter', MountCounter)
+  })
+
+  const render = (data: Record<string, unknown>) => mountSuspended(defineComponent({
+    setup() {
+      return { component: renderCustomElements(data) }
+    },
+    template: '<component :is="component" />',
+  }))
+
+  it('drops keys the component does not declare', async () => {
+    const wrapper = await render({
+      element: 'teaser',
+      title: 'A title',
+      heroType: 'wide',
+      authorHref: '/author/1',
+    })
+    expect(wrapper.html()).toBe('<article>A title</article>')
+  })
+
+  it('drops keys an asynchronously registered component does not declare', async () => {
+    const wrapper = await render({
+      element: 'async-teaser',
+      title: 'A title',
+      heroType: 'wide',
+    })
+    expect(wrapper.html()).toBe('<article>A title</article>')
+  })
+
+  it('keeps attributes that are valid on any element', async () => {
+    const wrapper = await render({
+      'element': 'teaser',
+      'title': 'A title',
+      'class': 'is-featured',
+      'id': 'teaser-1',
+      'data-id': 'teaser',
+      'aria-hidden': 'true',
+      'heroType': 'wide',
+    })
+    const article = wrapper.find('article').element
+    expect(Array.from(article.attributes).map(attribute => attribute.name).sort())
+      .toEqual(['aria-hidden', 'class', 'data-id', 'id'])
+  })
+
+  it('renders slots of the explicit format', async () => {
+    const wrapper = await render({
+      element: 'teaser',
+      props: { title: 'A title', heroType: 'wide' },
+      slots: { default: '<p>Slotted</p>' },
+    })
+    expect(wrapper.html()).toContain('<p>Slotted</p>')
+    expect(wrapper.html()).not.toContain('herotype')
+  })
+
+  it('patches in place instead of remounting on re-render', async () => {
+    const title = ref('First')
+    const wrapper = await mountSuspended(defineComponent({
+      setup() {
+        return () => h('div', [renderCustomElements({ element: 'mount-counter', title: title.value, heroType: 'wide' })])
+      },
+    }))
+    expect(mountCount).toBe(1)
+    expect(wrapper.html()).toContain('First')
+
+    title.value = 'Second'
+    await nextTick()
+    expect(wrapper.html()).toContain('Second')
+    expect(mountCount).toBe(1)
+  })
+})


### PR DESCRIPTION
A custom element is a data payload, but it is handed to the component as vnode
props: every key the component does not declare falls through to its root
element and is serialised as a non-standard HTML attribute. A Drupal-side field
addition then changes the markup of components that never asked for it.

This adds an opt-in way to close that at the CE render boundary:

```js
drupalCe: {
  customElementDeclaredPropsOnly: true
}
```

With it, a custom element component receives only the props it declares.
Everything else is dropped, and logged in dev mode. Attributes that are valid on
any element still pass through: `class`, `style`, `id`, `role`, `lang`, `dir`,
`hidden`, `tabindex`, `data-*`, `aria-*` and event listeners — that is how
Drupal's own `attributes` reach the markup.

Default is `false`: Vue attribute fallthrough stays the upstream behaviour, so
nothing changes for existing consumers unless they turn it on. The option only
touches elements rendered from custom element JSON; components used from a
template keep normal fallthrough either way.

### Why a wrapper

Nuxt registers global components asynchronously, so the declared props are not
readable when the vnode is created. `withDeclaredProps()` therefore returns an
async component that resolves to a filtering shim around the real one — the
same suspense behaviour as the component it replaces. The wrapper is cached per
resolved component, so a re-render reuses the vnode type instead of remounting
the custom-element subtree.

### Note for consumers turning it on

A component that took undeclared keys out of `$attrs` and relayed them to a
child (`v-bind="{ ...$props, ...$attrs }"`) must declare those props.

### Verification

- `test/nuxt/customElementProps.test.ts` — with the option off, undeclared keys
  still fall through (the upstream behaviour is asserted); with it on, declared
  props arrive, undeclared keys are dropped for both synchronously and
  asynchronously registered components, global attributes survive, slots still
  render, and a re-render patches in place rather than remounting.
- Full suite green: **35 files, 163 tests**, including the e2e project that
  builds and hydrates real Nuxt apps. `eslint .` clean apart from one
  pre-existing error in `playground/components/global/drupal-view--default.vue`.
- `test/nuxt/components/preview.test.ts` asserted on the leak itself: its
  fixture sent `body` as a legacy prop onto `node--default.vue`, which has a
  `body` *slot*, and the assertion passed only because the markup was rendered
  into a `body="<p>…</p>"` attribute. The fixture now sends it as a slot, so the
  test asserts the rendered body — correct with the option in either position.

### Relation to the component-side fix

This closes the CE boundary. It does not cover one kickstart component
`v-bind`ing a CE object onto another (`v-bind="image"` onto `LupusImage` /
`LupusPictureElement`), which never crosses that boundary — that is
[lupus-nuxt3-kickstart#1401](https://github.com/drunomics/lupus-nuxt3-kickstart/pull/1401),
where the receiving component sets `inheritAttrs: false` and binds a filtered
`$attrs`. Between the two, both classes are closed.

Ticket: [MCD-1400](https://drunomics.youtrack.cloud/issue/MCD-1400)
