### PR TITLE
fix: declare h3 runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.7",
+        "h3": "^1.15.11",
         "nuxt-component-preview": "^1.1.1",
         "ufo": "^1.6.4"
       },
@@ -8821,7 +8822,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
@@ -8914,7 +8914,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
       "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
@@ -9255,7 +9254,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-indent": {
@@ -10726,7 +10724,6 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
       "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.3",
@@ -11058,7 +11055,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
       "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
@@ -13425,7 +13421,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
       "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -15950,7 +15945,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/range-parser": {
@@ -17863,7 +17857,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unctx": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "defu": "^6.1.7",
+    "h3": "^1.15.11",
     "nuxt-component-preview": "^1.1.1",
     "ufo": "^1.6.4"
   },

--- a/test/runtime-dependencies.test.ts
+++ b/test/runtime-dependencies.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { IncomingMessage, ServerResponse } from 'node:http'
+import { Socket } from 'node:net'
+import { describe, expect, it } from 'vitest'
+
+describe('runtime dependencies', () => {
+  it('owns the H3 dependency used to forward Nitro response headers', () => {
+    const manifestUrl = new URL('../package.json', import.meta.url)
+    const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8'))
+    // A hoisted H3 2 can otherwise satisfy this undeclared import while
+    // Nuxt 4 still supplies an H3 1 event, breaking page SSR.
+    expect(manifest.dependencies.h3).toBeDefined()
+
+    const require = createRequire(manifestUrl)
+    const { createEvent, appendResponseHeader } = require('h3')
+    const request = new IncomingMessage(new Socket())
+    const response = new ServerResponse(request)
+    const event = createEvent(request, response)
+    appendResponseHeader(event, 'cache-tag', 'node:1')
+    appendResponseHeader(event, 'cache-tag', 'node:2')
+    expect(response.getHeader('cache-tag')).toEqual(['node:1', 'node:2'])
+  })
+})


### PR DESCRIPTION
Nuxt 4 page SSR can fail when this module resolves an unrelated, hoisted H3 2 installation. The runtime imports `appendResponseHeader` from `h3`, but the package does not declare H3. H3 2 expects `event.res.headers`, whereas Nuxt 4's Nitro server supplies an H3 1 event. Forwarding a Drupal response header then throws `Cannot read properties of undefined (reading 'append')`.

Declare `h3: ^1.15.11` as a runtime dependency and update the npm lockfile. This scopes resolution to the module without overriding H3 2 for packages that need it. It is independent of #538.

Validation:
- New dependency regression fails without the declaration and passes with it; it also exercises repeated response-header forwarding with Node request/response objects.
- Packaging suite: 8 tests passed.
- Basic Nuxt end-to-end suite: 3 tests passed.
- ESLint and diff checks passed.
- In a local Nuxt 4 production consumer, adding this exact dependency via pnpm `packageExtensions` changed SSR from HTTP 500 to HTTP 200. Homepage, service and project routes passed at mobile and desktop widths, with carousel and project-overlay interactions verified.
